### PR TITLE
Distribution stats and improvements

### DIFF
--- a/common/lumens.js
+++ b/common/lumens.js
@@ -1,0 +1,76 @@
+// This file contains functions used both in backend and frontend code.
+// Will be helpful to build distribution stats API.
+import axios from "axios";
+import BigNumber from "bignumber.js";
+import map from "lodash/map";
+import reduce from "lodash/reduce";
+import find from "lodash/find";
+
+const horizonLiveURL = "https://horizon.stellar.org";
+
+const accounts = {
+  worldGiveaway:       "GDKIJJIKXLOM2NRMPNQZUUYK24ZPVFC6426GZAEP3KUK6KEJLACCWNMX",
+  nonProfits:          "GDUY7J7A33TQWOSOQGDO776GGLM3UQERL4J3SPT56F6YS4ID7MLDERI4",
+  btcGiveawayCold:     "GDTNE54IWDB3UQLMIUSBKIDTMUW7FNKBU4VB2GVW4OL65BZN7W5VRNVY",
+  btcGiveawayHot:      "GBVVWWN4YP76FKGO7RB42FSZDYD2PBXY2PJY3F6JJWLYU74TKUG775UP",
+  invitesHot:          "GAX3BRBNB5WTJ2GNEFFH7A4CZKT2FORYABDDBZR5FIIT3P7FLS2EFOZZ",
+  sdfOperationalFunds: "GB6NVEN5HSUBKMYCE5ZOWSK5K23TBWRUQLZY3KNMXUZ3AQ2ESC4MY4AQ",
+  vestingPool:         "GANOI26P6VAUL4NFVA4FAIOIBOR46NORONBIWUPRIGAMP7T5W5MOY4O6",
+  cashAccount:         "GAYOCVRRNXGQWREOZBDP4UEW475NKZKLA4EIEIBKBSJN2PQQWUQ5KGUH",
+  inflationDest:       "GDWNY2POLGK65VVKIH5KQSH7VWLKRTQ5M6ADLJAYC2UEHEBEARCZJWWI",
+}
+
+export function getLumenBalance(horizonURL, accountId) {
+  return axios.get(`${horizonURL}/accounts/${accountId}`)
+    .then(response => {
+      var xlmBalance = find(response.data.balances, b => b.asset_type == 'native');
+      return xlmBalance.balance;
+    });
+}
+
+export function totalCoins(horizonURL) {
+  return axios.get(`${horizonURL}/ledgers/?order=desc&limit=1`)
+    .then(response => response.data._embedded.records[0].total_coins);
+}
+
+export function distributionDirectSignup() {
+  return Promise.all([
+    getLumenBalance(horizonLiveURL, accounts.worldGiveaway),
+    getLumenBalance(horizonLiveURL, accounts.invitesHot),
+  ]).then(balances => {
+    var amount = new BigNumber(50*Math.pow(10, 9)); // 50B
+    amount = amount.minus(balances[0]);
+    amount = amount.minus(balances[1]);
+    return amount.toString();
+  })
+}
+
+export function distributionBitcoinProgram() {
+  return Promise.all([
+    getLumenBalance(horizonLiveURL, accounts.btcGiveawayHot),
+    getLumenBalance(horizonLiveURL, accounts.btcGiveawayCold),
+  ]).then(balances => {
+    var amount = new BigNumber(20*Math.pow(10, 9)); // 20B
+    amount = amount.minus(balances[0]);
+    amount = amount.minus(balances[1]);
+    return amount.toString();
+  })
+}
+
+export function distributionNonprofitProgram() {
+  return getLumenBalance(horizonLiveURL, accounts.nonProfits).then(balance => {
+    var amount = new BigNumber(25*Math.pow(10, 9)); // 25B
+    amount = amount.minus(balance);
+    return amount.toString();
+  })
+}
+
+export function availableCoins() {
+  var balanceMap = map(accounts, id => getLumenBalance(horizonLiveURL, id));
+  return Promise.all(balanceMap).then(balances => {
+    var amount = reduce(balances, (sum, balance) => sum.add(balance), new BigNumber(0));
+    return totalCoins(horizonLiveURL)
+      .then(totalCoins => new BigNumber(totalCoins).minus(amount).toString());
+  })
+}
+

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -11,11 +11,14 @@ gulp.task('default', ['develop']);
 var webpackOptions = {
   entry: {
     app: "./src/app.js",
-    vendor: ["react", "react-dom", "lodash", "muicss", "stellar-sdk", "axios", "d3", "react-d3-components", "fbemitter"]
+    vendor: ["react", "react-dom", "muicss", "stellar-sdk", "axios", "d3", "fbemitter"]
   },
   devtool: "source-map",
   resolve: {
-    root: ['src'],
+    root: [
+      path.resolve('src'),
+      path.resolve('common')
+    ],
     modulesDirectories: ["node_modules"]
   },
   module: {
@@ -31,21 +34,13 @@ var webpackOptions = {
 };
 
 gulp.task('develop', function(done) {
-  var mixpanelSecret = '7d6b4a91f04cd8228ff3e2387f26277d' // empty project
-  if (process.env.MIXPANEL_SECRET) {
-    mixpanelSecret = process.env.MIXPANEL_SECRET;
-  }
-
   var options = merge(webpackOptions, {
     output: {
       filename: "[name].js",
       path: './.tmp'
     },
     plugins: [
-      new webpack.optimize.CommonsChunkPlugin("vendor", "vendor.js"),
-      new webpack.DefinePlugin({
-        'MIXPANEL_SECRET': JSON.stringify(mixpanelSecret)
-      }),
+      new webpack.optimize.CommonsChunkPlugin("vendor", "vendor.js")
     ]
   });
 
@@ -91,8 +86,7 @@ gulp.task('build', function(done) {
       new webpack.DefinePlugin({
         'process.env': {
           NODE_ENV: JSON.stringify('production'),
-        },
-        'MIXPANEL_SECRET': JSON.stringify(process.env.MIXPANEL_SECRET)
+        }
       }),
       new webpack.optimize.UglifyJsPlugin()
     ]

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "babel-loader": "^6.3.2",
     "babel-preset-es2015": "^6.22.0",
     "babel-preset-react": "^6.23.0",
+    "babel-register": "^6.24.0",
     "bignumber.js": "^3.0.1",
     "browser-sync": "^2.18.2",
     "express": "^4.14.0",

--- a/src/components/AccountBalance.js
+++ b/src/components/AccountBalance.js
@@ -1,14 +1,13 @@
 import React from 'react';
+import AmountWidget from './AmountWidget';
 import Panel from 'muicss/lib/react/panel';
 import axios from 'axios';
-import {find} from 'lodash';
+import find from 'lodash/find';
 
-export default class AccountBalance extends React.Component {
+export default class AccountBalance extends AmountWidget {
   constructor(props) {
     super(props);
     this.url = `${this.props.horizonURL}/accounts/${this.props.id}`;
-    this.state = {loading: true};
-    this.updateBalance();
   }
 
   componentDidMount() {
@@ -16,6 +15,7 @@ export default class AccountBalance extends React.Component {
       () => this.updateBalance(),
       5*60*1000
     );
+    this.updateBalance();
   }
 
   componentWillUnmount() {
@@ -26,38 +26,13 @@ export default class AccountBalance extends React.Component {
     axios.get(this.url)
       .then(response => {
         let xlmBalance = find(response.data.balances, b => b.asset_type == 'native');
-        let balance = xlmBalance.balance;
-        this.setState({balance, loading: false});
+        let amount = xlmBalance.balance;
+        let code = "XLM";
+        this.setState({amount, code, loading: false});
       });
   }
 
-  render() {
-    let balance;
-    if (this.state.loading) {
-      balance = "Loading..."
-    } else {
-      if (this.state.balance >= 1000000000) {
-        balance = Math.floor(this.state.balance / 1000000000)+"B";
-      } else if (this.state.balance >= 1000000) {
-        balance = Math.round(this.state.balance / 10000)/100+"M";
-      } else if (this.state.balance < 1000000 && this.state.balance >= 100000) {
-        balance = Math.floor(this.state.balance / 1000)+"k";
-      } else {
-        balance = Math.floor(this.state.balance);
-      }
-
-      balance += " XLM";
-    }
-
-    return (
-      <Panel>
-        <div className="widget-name">
-          {this.props.name}: <a href={this.url} target="_blank">{this.props.id.substr(0, 10)}</a>
-        </div>
-        <div className="mui--text-display3 mui--text-center">
-          {balance}
-        </div>
-      </Panel>
-    );
+  renderName() {
+    return <span>{this.props.name}: <code><a href={this.url} target="_blank">{this.props.id.substr(0, 4)}</a></code></span>
   }
 }

--- a/src/components/AccountLink.js
+++ b/src/components/AccountLink.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import Panel from 'muicss/lib/react/panel';
 import axios from 'axios';
-import {find} from 'lodash';
+import find from 'lodash/find';
 
 const knownAccounts = {
   'GCKX3XVTPVNFXQWLQCIBZX6OOPOIUT7FOAZVNOFCNEIXEZFRFSPNZKZT': 'Coins base',

--- a/src/components/AmountWidget.js
+++ b/src/components/AmountWidget.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import Panel from 'muicss/lib/react/panel';
+import BigNumber from 'bignumber.js';
+
+export default class AmountWidget extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {loading: true};
+  }
+
+  renderName() {
+    return null;
+  }
+
+  render() {
+    let amountBig;
+    let amount;
+    if (this.state.loading) {
+      amountBig = "Loading..."
+    } else {
+      if (this.state.amount >= 1000000000) {
+        amountBig = Math.round(this.state.amount / 10000000)/100+"B";
+      } else if (this.state.amount >= 1000000) {
+        amountBig = Math.round(this.state.amount / 10000)/100+"M";
+      } else if (this.state.amount < 1000000 && this.state.amount >= 100000) {
+        amountBig = Math.floor(this.state.amount / 1000)+"k";
+      } else {
+        amountBig = Math.floor(this.state.amount);
+      }
+
+      if (this.state.code) {
+        amountBig += ` ${this.state.code}`;
+      }
+
+      amount = new BigNumber(this.state.amount).toFormat(7);
+    }
+
+
+    return (
+      <Panel>
+        <div className="widget-name">
+          {this.renderName()}
+        </div>
+        <div className="mui--text-display3 mui--text-center">
+          {amountBig}
+        </div>
+        <div className="mui--text-caption mui--text-center">
+          {this.state.loading ? "" : <span>{amount} {this.state.code}</span>}
+        </div>
+      </Panel>
+    );
+  }
+}

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -4,15 +4,19 @@ import Button from 'muicss/lib/react/button';
 import {EventEmitter} from 'fbemitter';
 import axios from 'axios';
 import {Server} from 'stellar-sdk';
-import {assign} from 'lodash';
+import assign from 'lodash/assign';
 
 import AppBar from './AppBar';
 import AccountBalance from './AccountBalance';
+import DistributionProgress from './DistributionProgress';
 import NetworkStatus from './NetworkStatus';
 import LedgerCloseChart from './LedgerCloseChart';
 import ListAccounts from './ListAccounts';
+import LumensAvailable from './LumensAvailable';
+import LumensGivenAway from './LumensGivenAway';
 import PublicNetworkLedgersHistoryChart from './PublicNetworkLedgersHistoryChart';
 import RecentOperations from './RecentOperations';
+import TotalCoins from './TotalCoins';
 import TransactionsChart from './TransactionsChart';
 import {LIVE_NEW_LEDGER, LIVE_NEW_OPERATION, TEST_NEW_LEDGER, TEST_NEW_OPERATION} from '../events';
 
@@ -24,14 +28,15 @@ export default class App extends React.Component {
     super(props);
     this.state = {};
     this.emitter = new EventEmitter();
+    this.sleepDetector();
+  }
 
+  componentDidMount() {
     this.streamLedgers(horizonLive, LIVE_NEW_LEDGER);
     this.streamOperations(horizonLive, LIVE_NEW_OPERATION);
 
     this.streamLedgers(horizonTest, TEST_NEW_LEDGER);
     this.streamOperations(horizonTest, TEST_NEW_OPERATION);
-
-    this.sleepDetector();
   }
 
   sleepDetector() {
@@ -127,6 +132,29 @@ export default class App extends React.Component {
               </div>
             </div>
           </section>
+
+          <section>
+            <h1>Lumen distribution</h1>
+
+            <div className="mui-col-md-4">
+              <DistributionProgress />
+            </div>
+
+            <div className="mui-col-md-4">
+              <TotalCoins
+                horizonURL={horizonLive}
+                />
+            </div>
+
+            <div className="mui-col-md-4">
+              <LumensAvailable />
+            </div>
+
+            <div className="mui-col-md-4">
+              <LumensGivenAway />
+            </div>
+          </section>
+
           <section>
             <h1>Test network status</h1>
             <div className="mui-col-md-4">

--- a/src/components/AppBar.js
+++ b/src/components/AppBar.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import Button from 'muicss/lib/react/button';
-import {assign} from 'lodash';
-import {SLIDE} from '../events';
+import assign from 'lodash/assign';
 
 export default class AppBar extends React.Component {
   render() {

--- a/src/components/DistributionProgress.js
+++ b/src/components/DistributionProgress.js
@@ -1,0 +1,116 @@
+import React from 'react';
+import Panel from 'muicss/lib/react/panel';
+import axios from 'axios';
+import BigNumber from 'bignumber.js';
+import PieChart from 'react-d3-components/lib/PieChart';
+import {scale} from 'd3';
+import {distributionDirectSignup, distributionBitcoinProgram, distributionNonprofitProgram} from '../../common/lumens.js';
+
+export default class DistributionProgress extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {loading: true, chartWidth: 400, chartHeigth: this.props.chartHeigth || 120};
+  }
+
+  componentDidMount() {
+    this.timerID = setInterval(
+      () => this.updateData(),
+      5*60*1000
+    );
+    this.updateData();
+    setInterval(() => this.setState({chartWidth: this.panel.offsetWidth-20}), 1000);
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.timerID);
+  }
+
+  updateData() {
+    let data = {label: 'Distribution', values: []};
+
+    Promise.all([
+      distributionDirectSignup(),
+      distributionBitcoinProgram(),
+      distributionNonprofitProgram()
+    ]).then(results => {
+        let directSignup = results[0];
+        let bitcoinProgram = results[1];
+        let nonProfits = results[2];
+
+        let directSignupLeft = new BigNumber(50*Math.pow(10, 9)).minus(directSignup);
+        let bitcoinProgramLeft = new BigNumber(20*Math.pow(10, 9)).minus(bitcoinProgram);
+        let nonProfitsLeft = new BigNumber(25*Math.pow(10, 9)).minus(nonProfits);
+
+        let percentDirectSignup = this.percentOf(directSignup, 50);
+        data.values.push({x: `Direct signup program (${percentDirectSignup}%)`, y: directSignup, p: percentDirectSignup});
+        data.values.push({x: 'Direct signup program left', y: directSignupLeft});
+
+        let percentBitcoinProgram = this.percentOf(bitcoinProgram, 20);
+        data.values.push({x: `Bitcoin program (${percentBitcoinProgram}%)`, y: bitcoinProgram, p: percentBitcoinProgram});
+        data.values.push({x: 'Bitcoin program left', y: bitcoinProgramLeft});
+
+        let percentNonProfits = this.percentOf(nonProfits, 25);
+        data.values.push({x: `Non-profits program (${percentNonProfits}%)`, y: nonProfits, p: percentNonProfits});
+        data.values.push({x: 'Non-profits program left ', y: nonProfitsLeft});
+
+        data.values.push({x: 'SDF operational costs', y: "5000000000"});
+        this.setState({data, loading: false});
+      });
+  }
+
+  percentOf(x, yBillions) {
+    return new BigNumber(x).div(yBillions*Math.pow(10, 9)).mul(100).round(2).toFormat(2).toString();
+  }
+
+  render() {
+    return (
+      <div ref={(el) => { this.panel = el; }}>
+        <Panel>
+          <div className="widget-name">
+            Distribution Progress
+            <a href="/api/lumens" target="_blank" className="api-link">API</a>
+          </div>
+          {this.state.loading ?
+              'Loading...'
+              :
+              <div>
+                <PieChart
+                  data={this.state.data}
+                  innerRadius={30}
+                  outerRadius={40}
+                  sort={null}
+                  scale={scale.category20()}
+                  width={this.state.chartWidth}
+                  height={this.state.chartHeigth}
+                  margin={{top: 10, bottom: 10, left: 10, right: 10}} />
+                <table className="mui-table small">
+                  <thead>
+                    <tr>
+                      <th>Program</th>
+                      <th>Progress</th>
+                      <th>Amount Given Away</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {
+                      Object.keys(this.state.data.values).map(key => { 
+                        let row = this.state.data.values[key];
+                        if (!row.p) {
+                          return;
+                        }
+                        return <tr key={key}>
+                          <td>{row.x}</td>
+                          <td className="amount-column">{row.p ? `${row.p}%` : null}</td>
+                          <td className="amount-column">{new BigNumber(row.y).toFormat(0, BigNumber.ROUND_HALF_UP)} XLM</td>
+                        </tr>
+                      })
+                    }
+                  </tbody>
+                </table>
+              </div>
+          }
+        </Panel>
+      </div>
+    );
+  }
+}

--- a/src/components/LedgerCloseChart.js
+++ b/src/components/LedgerCloseChart.js
@@ -2,8 +2,10 @@ import React from 'react';
 import Panel from 'muicss/lib/react/panel';
 import axios from 'axios';
 import {scale} from 'd3';
-import {BarChart} from 'react-d3-components';
-import {assign, each, clone} from 'lodash';
+import BarChart from 'react-d3-components/lib/BarChart';
+import assign from 'lodash/assign';
+import each from 'lodash/each';
+import clone from 'lodash/clone';
 
 export default class LedgerChartClose extends React.Component {
   constructor(props) {
@@ -11,13 +13,17 @@ export default class LedgerChartClose extends React.Component {
     this.panel = null;
     this.colorScale = scale.category10();
     this.state = {loading: true, chartWidth: 400, chartHeigth: this.props.chartHeigth || 120};
+    this.url = `${this.props.horizonURL}/ledgers?order=desc&limit=${this.props.limit}`;
+  }
+
+  componentDidMount() {
     this.getLedgers();
     // Update chart width
     setInterval(() => this.setState(assign(this.state, {chartWidth: this.panel.offsetWidth-20})), 1000);
   }
 
   getLedgers() {
-    axios.get(`${this.props.horizonURL}/ledgers?order=desc&limit=${this.props.limit}`)
+    axios.get(this.url)
       .then(response => {
         let data = [{
           label: "Ledger Close",
@@ -62,6 +68,7 @@ export default class LedgerChartClose extends React.Component {
         <Panel>
           <div className="widget-name">
             Last {this.props.limit} ledgers close times: {this.props.network}
+            <a href={this.url} target="_blank" className="api-link">API</a>
           </div>
           {this.state.loading ?
             'Loading...'

--- a/src/components/ListAccounts.js
+++ b/src/components/ListAccounts.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import Panel from 'muicss/lib/react/panel';
 import axios from 'axios';
-import {clone, find, reduce} from 'lodash';
+import clone from 'lodash/clone';
+import find from 'lodash/find';
+import reduce from 'lodash/reduce';
 import AccountLink from './AccountLink';
 import BigNumber from 'bignumber.js';
 
@@ -9,7 +11,6 @@ export default class ListAccounts extends React.Component {
   constructor(props) {
     super(props);
     this.state = {balances: {}};
-    this.loadBalances();
   }
 
   loadBalances() {
@@ -30,6 +31,7 @@ export default class ListAccounts extends React.Component {
   componentDidMount() {
     // Update balances
     this.timerID = setInterval(() => this.loadBalances(), 60*60*1000);
+    this.loadBalances();
   }
 
   componentWillUnmount() {

--- a/src/components/LumensAvailable.js
+++ b/src/components/LumensAvailable.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import AmountWidget from './AmountWidget';
+import Panel from 'muicss/lib/react/panel';
+import {availableCoins} from '../../common/lumens.js';
+
+const horizonURL = "https://horizon.stellar.org";
+
+export default class LumensAvailable extends AmountWidget {
+  constructor(props) {
+    super(props);
+  }
+
+  componentDidMount() {
+    this.timerID = setInterval(
+      () => this.updateAmount(),
+      60*60*1000
+    );
+    this.updateAmount();
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.timerID);
+  }
+
+  updateAmount() {
+    availableCoins().then(amount => {
+      this.setState({amount, code: "XLM", loading: false});
+    });
+  }
+
+  renderName() {
+    return <div>
+      <span>Lumens Available (not held by SDF)</span>
+      <a href="/api/lumens" target="_blank" className="api-link">API</a>
+    </div>
+  }
+}

--- a/src/components/LumensGivenAway.js
+++ b/src/components/LumensGivenAway.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import AmountWidget from './AmountWidget';
+import Panel from 'muicss/lib/react/panel';
+import BigNumber from 'bignumber.js';
+import axios from 'axios';
+import find from 'lodash/find';
+import {distributionDirectSignup} from '../../common/lumens.js';
+
+export default class LumensGivenAway extends AmountWidget {
+  constructor(props) {
+    super(props);
+  }
+
+  componentDidMount() {
+    this.timerID = setInterval(
+      () => this.updateAmount(),
+      60*60*1000
+    );
+    this.updateAmount();
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.timerID);
+  }
+
+  updateAmount() {
+    distributionDirectSignup().then(amount => {
+      this.setState({amount, code: "XLM", loading: false});
+    })
+  }
+
+  renderName() {
+    return <div>
+      <span>Lumens Given Away</span>
+      <a href="/api/lumens" target="_blank" className="api-link">API</a>
+    </div>
+  }
+}

--- a/src/components/NetworkStatus.js
+++ b/src/components/NetworkStatus.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import Panel from 'muicss/lib/react/panel';
 import axios from 'axios';
-import _ from 'lodash';
+import round from 'lodash/round';
 
 // ledgersInAverageCalculation defines how many last ledgers should be
 // considered when calculating average ledger length.
@@ -11,7 +11,6 @@ export default class NetworkStatus extends React.Component {
   constructor(props) {
     super(props);
     this.state = {loading: true};
-    this.getLastLedgers();
   }
 
   // This method will be called when a new ledger is created.
@@ -61,6 +60,7 @@ export default class NetworkStatus extends React.Component {
 
       this.setState({closedAgo});
     }, 1000);
+    this.getLastLedgers();
   }
 
   componentWillUnmount() {
@@ -108,7 +108,7 @@ export default class NetworkStatus extends React.Component {
           {!this.state.loading ?
             <div>
             Last ledger: #{this.state.lastLedgerSequence}<br />
-            Average ledger close time in the last {ledgersInAverageCalculation} ledgers: {_.round(averageLedgerLength, 2)} sec.<br />
+            Average ledger close time in the last {ledgersInAverageCalculation} ledgers: {round(averageLedgerLength, 2)} sec.<br />
             Last ledger closed at: {this.state.closedAt.toString()} in {this.state.lastLedgerLength/1000} sec.
             </div>
           : ''}

--- a/src/components/PublicNetworkLedgersHistoryChart.js
+++ b/src/components/PublicNetworkLedgersHistoryChart.js
@@ -2,8 +2,10 @@ import React from 'react';
 import Panel from 'muicss/lib/react/panel';
 import axios from 'axios';
 import {scale, format} from 'd3';
-import {BarChart} from 'react-d3-components';
-import {assign, clone, each} from 'lodash';
+import BarChart from 'react-d3-components/lib/BarChart';
+import assign from 'lodash/assign';
+import clone from 'lodash/clone';
+import each from 'lodash/each';
 
 export default class PublicNetworkLedgersHistoryChart extends React.Component {
   constructor(props) {
@@ -11,10 +13,11 @@ export default class PublicNetworkLedgersHistoryChart extends React.Component {
     this.panel = null;
     this.colorScale = scale.category10();
     this.state = {loading: true, chartWidth: 400, chartHeight: this.props.chartHeight || 120};
+  }
 
+  componentDidMount() {
     this.getLedgers();
     setInterval(() => this.getLedgers(), 1000*60*5);
-
     // Update chart width
     setInterval(() => this.setState(assign(this.state, {chartWidth: this.panel.offsetWidth-20})), 1000);
   }

--- a/src/components/RecentOperations.js
+++ b/src/components/RecentOperations.js
@@ -2,7 +2,9 @@ import React from 'react';
 import Panel from 'muicss/lib/react/panel';
 import axios from 'axios';
 import moment from 'moment';
-import {clone, each, defaults} from 'lodash';
+import clone from 'lodash/clone';
+import each from 'lodash/each';
+import defaults from 'lodash/defaults';
 import AccountLink from './AccountLink';
 import BigNumber from 'bignumber.js';
 
@@ -11,7 +13,12 @@ export default class RecentOperations extends React.Component {
     super(props);
     this.props = defaults(props, {limit: 10});
     this.state = {loading: true, operations: []};
-    this.getRecentOperations();
+
+    this.url = `${this.props.horizonURL}/operations`;
+    if (this.props.account) {
+      this.url = `${this.props.horizonURL}/accounts/${this.props.account}/operations`;
+    }
+    this.url = `${this.url}?order=desc&limit=${this.props.limit}`;
   }
 
   onNewOperation(operation) {
@@ -32,11 +39,7 @@ export default class RecentOperations extends React.Component {
   }
 
   getRecentOperations() {
-    let url = `${this.props.horizonURL}/operations`;
-    if (this.props.account) {
-      url = `${this.props.horizonURL}/accounts/${this.props.account}/operations`;
-    }
-    axios.get(`${url}?order=desc&limit=${this.props.limit}`)
+    axios.get(this.url)
       .then(response => {
         let records = response.data._embedded.records;
         let operations = this.state.operations;
@@ -83,6 +86,7 @@ export default class RecentOperations extends React.Component {
   componentDidMount() {
     // Update seconds ago
     this.timerID = setInterval(() => this.updateAgo(), 10*1000);
+    this.getRecentOperations();
   }
 
   componentWillUnmount() {
@@ -143,6 +147,7 @@ export default class RecentOperations extends React.Component {
       <Panel>
         <div className="widget-name">
           Recent operations: {this.props.label} {this.props.account ? this.props.account.substr(0, 4) : ''}
+          <a href={this.url} target="_blank" className="api-link">API</a>
         </div>
         <table className="mui-table small">
         <thead>

--- a/src/components/TotalCoins.js
+++ b/src/components/TotalCoins.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import AmountWidget from './AmountWidget';
+import Panel from 'muicss/lib/react/panel';
+import axios from 'axios';
+import {totalCoins} from '../../common/lumens.js';
+
+export default class TotalCoins extends AmountWidget {
+  constructor(props) {
+    super(props);
+  }
+
+  componentDidMount() {
+    this.timerID = setInterval(
+      () => this.updateAmount(),
+      60*60*1000
+    );
+    this.updateAmount();
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.timerID);
+  }
+
+  updateAmount() {
+    totalCoins(this.props.horizonURL)
+      .then(amount => {
+        let code = "XLM";
+        this.setState({amount, code, loading: false});
+      });
+  }
+
+  renderName() {
+    return <div>
+      <span>Total Lumens</span>
+      <a href={`${this.props.horizonURL}/ledgers/?order=desc&limit=1`} target="_blank" className="api-link">API</a>
+    </div>
+  }
+}

--- a/src/components/TransactionsChart.js
+++ b/src/components/TransactionsChart.js
@@ -2,8 +2,10 @@ import React from 'react';
 import Panel from 'muicss/lib/react/panel';
 import axios from 'axios';
 import {scale, format} from 'd3';
-import {BarChart} from 'react-d3-components';
-import {assign, clone, each} from 'lodash';
+import BarChart from 'react-d3-components/lib/BarChart';
+import assign from 'lodash/assign';
+import clone from 'lodash/clone';
+import each from 'lodash/each';
 
 export default class TransactionsChart extends React.Component {
   constructor(props) {
@@ -11,8 +13,15 @@ export default class TransactionsChart extends React.Component {
     this.panel = null;
     this.colorScale = scale.category10();
     this.state = {loading: true, chartWidth: 400, chartHeigth: this.props.chartHeigth || 120};
-    this.getLedgers();
+    this.url = `${this.props.horizonURL}/ledgers?order=desc&limit=${this.props.limit}`;
+  }
 
+  componentDidMount() {
+    this.timerID = setInterval(
+      () => this.updateAmount(),
+      60*60*1000
+    );
+    this.getLedgers();
     // Update chart width
     setInterval(() => this.setState(assign(this.state, {chartWidth: this.panel.offsetWidth-20})), 1000);
   }
@@ -27,7 +36,7 @@ export default class TransactionsChart extends React.Component {
   }
 
   getLedgers() {
-    axios.get(`${this.props.horizonURL}/ledgers?order=desc&limit=${this.props.limit}`)
+    axios.get(this.url)
       .then(response => {
         let data = [{
           label: "Transactions",
@@ -53,6 +62,8 @@ export default class TransactionsChart extends React.Component {
           <div className="widget-name">
             <span style={{borderBottom: '2px solid #0074B7'}}>Txs
             </span> &amp; <span style={{borderBottom: '2px solid #0074B7'}}>Op</span><span style={{borderBottom: '2px solid #FF6F00'}}>s</span> in the last {this.props.limit} ledgers: {this.props.network}
+
+            <a href={this.url} target="_blank" className="api-link">API</a>
           </div>
           {this.state.loading ?
             'Loading...'

--- a/src/index.html
+++ b/src/index.html
@@ -73,6 +73,26 @@
       clear: both;
     }
 
+    .api-link {
+      float: right;
+      text-transform: uppercase;
+      font-size: 0.8em;
+      background-color: rgb(255, 111, 0);
+      color: white;
+      padding: 2px;
+      font-weight: bold;
+    }
+
+    .api-link:hover {
+      color: white;
+      text-decoration: none;
+    }
+
+    .api-link:active {
+      color: white;
+      text-decoration: none;
+    }
+
     .amount-column {
       text-align: right;
     }
@@ -154,6 +174,10 @@
     }
 
     .axis text {
+      font-size: 10px;
+    }
+
+    .arc text {
       font-size: 10px;
     }
   </style>


### PR DESCRIPTION
* Added distribution stats that can also be accessed via a simple API.
* Created a generic `AmountWidget` to display amounts. It's used as a parent class in Total Lumens widget to display total number of lumens but also in Friendbot to display current balance of friendbot.
* Added API link in top right corner of widgets if data can be accessed via API or Horizon.
* Made builds smaller by loading required `lodash` and `react-d3-components ` functions instead of full library code.
* Added smaller improvements and removed unused code.