### PR TITLE
Redesigned nodes for simpler view

### DIFF
--- a/app.js
+++ b/app.js
@@ -84,7 +84,7 @@ app.get('/api/nodes', function(req, res) {
 
   var dates = [];
   var multi = redisClient.multi();
-  var measurements = 70;
+  var measurements = 150;
 
   for (var i = 0; i < measurements; i++) {
     dates.push(date.format("YYYY-MM-DD HH:mm"));

--- a/src/components/Node.js
+++ b/src/components/Node.js
@@ -103,34 +103,36 @@ export default class Node extends React.Component {
     return (
       <div ref={(el) => { this.panel = el; }}>
         <Panel className="mui-col-md-12 node-panel">
-          <div className="mui-col-md-3 mui-col-xs-4 node-circle-container">
-            <div className={this.renderColor()} />
-              {this.props.data.name}
-            </div>
-            <div className={"mui-col-md-3 mui-col-xs-4"}>
-              {this.props.data.host}:{this.props.data.port}
-            </div>
-            {this.state.loading ?
-              'Loading...' :
-              <div className={"mui-col-md-6 mui-col-xs-4 node-barchart-container"}>
-                {
-                  this.state.small ? "" :
-                  <div className="node-hovered-container">
-                    <p className={"node-pubkey"}>{this.props.data.publicKey} </p>
-                  </div>
-                }
-                <div className={this.state.small ? "" : "node-barchart"}>
-                  <BarChart
-                    data={this.renderData()}
-                    width={this.state.chartWidth}
-                    colorScale={this.colorScale}
-                    height={this.state.chartHeigth} />
-                </div>
-                {
-                  this.state.small ? <i className="material-icons node-dropdown-button" onClick={() => this.setState({expanded : !this.state.expanded})}>expand_more</i> : ""
-                }
+          <div className="node-panel-large">
+            <div className="mui-col-md-3 mui-col-xs-4 node-circle-container">
+              <div className={this.renderColor()} />
+                {this.props.data.name}
               </div>
-            }
+              <div className={"mui-col-md-3 mui-col-xs-4"}>
+                {this.props.data.host}:{this.props.data.port}
+              </div>
+              {this.state.loading ?
+                'Loading...' :
+                <div className={"mui-col-md-6 mui-col-xs-4 node-barchart-container"}>
+                  {
+                    this.state.small ? "" :
+                    <div className="node-hovered-container">
+                      <p className={"node-pubkey"}>{this.props.data.publicKey} </p>
+                    </div>
+                  }
+                  <div className={"node-barchart"}>
+                    <BarChart
+                      data={this.renderData()}
+                      width={this.state.chartWidth}
+                      colorScale={this.colorScale}
+                      height={this.state.chartHeigth} />
+                  </div>
+                  {
+                    this.state.small ? <i className="material-icons node-dropdown-button" onClick={() => this.setState({expanded : !this.state.expanded})}>expand_more</i> : ""
+                  }
+                </div>
+              }
+            </div>
             {this.state.expanded && this.state.small ?
               <div className="node-dropdown">
                 <table className="mui-table small" style={{'tableLayout': 'fixed'}}>

--- a/src/components/Node.js
+++ b/src/components/Node.js
@@ -7,15 +7,23 @@ export default class Node extends React.Component {
   constructor(props) {
     super(props);
     this.colorScale = scale.category10();
-    this.state = {loading: true, chartWidth: 300, chartHeigth: this.props.chartHeigth || 50};
+    this.state = {
+      loading: true,
+      chartWidth: 400,
+      chartHeigth: 20,
+      expanded : false,
+      small: false,
+    };
   }
 
   componentDidMount() {
-    // Update chart width
+    //Update chart width
     setInterval(() => {
-      let value = this.panel.offsetWidth-50;
-      if (this.state.chartWidth != value) {
-        this.setState({chartWidth: value});
+      let panelWidth = this.panel.offsetWidth;
+      if (window.innerWidth < 1150 && !this.state.small) {
+        this.setState({small: true, chartWidth: panelWidth/20});
+      } else if (window.innerWidth >= 1150 && (this.state.small || this.state.chartWidth != panelWidth/2)) {
+        this.setState({small: false, expanded: false, chartWidth: panelWidth/2});
       }
     }, 5000);
   }
@@ -69,60 +77,94 @@ export default class Node extends React.Component {
     this.setState({loading: false, data, isNew, state});
   }
 
+  renderData() {
+    if (this.state.small) {
+      return this.state.data.map(x => ({
+        label: x.label,
+        values: x.values.slice(x.values.length-5),
+      }));
+    }
+    return this.state.data;
+  }
+
+  renderColor() {
+    if (this.state.loading) {
+      return "node-circle";
+    } else if (this.state.state === "up") {
+      return "node-circle blue";
+    } else if (this.state.state === "problems") {
+      return "node-circle orange";
+    } else {
+      return "node-circle red";
+    }
+  }
+
   render() {
     return (
-      <div className="mui-col-md-3" ref={(el) => { this.panel = el; }}>
-        <Panel>
-          <div className="widget-name">
-            {this.props.data.name}
-            {this.state.isNew ? <span className="tag">new!</span> : null}
-            {this.props.data.verified ? <span className="tag"><i className="material-icons">verified_user</i><span className="hide-narrow-panel"> verified entity</span></span> : null}
-          </div>
-          <table className="mui-table small" style={{'tableLayout': 'fixed'}}>
-            <tbody>
-              <tr>
-                <td style={{width: '10%'}}><strong>Status</strong></td>
-                <td className="amount-column">
-                {
-                  !this.state.loading ?
-                    this.state.state == 'up' ?
-                      <strong style={{color: "#2196f3"}}>Up!</strong>
-                      :
-                    this.state.state == 'problems' ?
-                      <strong style={{color: "orange"}}>Problems...</strong>
-                      :
-                      <strong style={{color: "red"}}>Down!</strong>
-                    :
-                    <span>Loading...</span>
-                }
-                </td>
-              </tr>
-              <tr>
-                <td><strong>Host</strong></td>
-                <td className="amount-column">{this.props.data.host}:{this.props.data.port}</td>
-              </tr>
-              <tr>
-                <td colSpan="2"><strong>Public Key</strong></td>
-              </tr>
-              <tr>
-                <td colSpan="2" style={{wordWrap: "break-word"}}>{this.props.data.publicKey}</td>
-              </tr>
-            </tbody>
-          </table>
-          {this.state.loading ?
-            'Loading...'
-            :
-            <div>
-              <BarChart
-                data={this.state.data}
-                width={this.state.chartWidth}
-                colorScale={this.colorScale}
-                height={this.state.chartHeigth}
-                margin={{top: 10, bottom: 8, left: -18, right: -15}} />
-              <div className="small gray margin-top10">
-                Checked every 5 mins. Last: {this.props.uptime[0].date} UTC
-              </div>
+      <div ref={(el) => { this.panel = el; }}>
+        <Panel className="mui-col-md-12 node-panel">
+          <div className="mui-col-md-3 mui-col-xs-4 node-circle-container">
+            <div className={this.renderColor()} />
+              {this.props.data.name}
             </div>
+            <div className={"mui-col-md-3 mui-col-xs-4"}>
+              {this.props.data.host}:{this.props.data.port}
+            </div>
+            {this.state.loading ?
+              'Loading...' :
+              <div className={"mui-col-md-6 mui-col-xs-4 node-barchart-container"}>
+                {
+                  this.state.small ? "" :
+                  <div className="node-hovered-container">
+                    <p className={"node-pubkey"}>{this.props.data.publicKey} </p>
+                  </div>
+                }
+                <div className={this.state.small ? "" : "node-barchart"}>
+                  <BarChart
+                    data={this.renderData()}
+                    width={this.state.chartWidth}
+                    colorScale={this.colorScale}
+                    height={this.state.chartHeigth} />
+                </div>
+                {
+                  this.state.small ? <i className="material-icons node-dropdown-button" onClick={() => this.setState({expanded : !this.state.expanded})}>expand_more</i> : ""
+                }
+              </div>
+            }
+            {this.state.expanded && this.state.small ?
+              <div className="node-dropdown">
+                <table className="mui-table small" style={{'tableLayout': 'fixed'}}>
+                  <tbody>
+                    <tr>
+                      <td style={{width: '10%'}}><strong>Status</strong></td>
+                      <td className="amount-column">
+                      {
+                        !this.state.loading ?
+                          this.state.state == 'up' ?
+                            <strong style={{color: "#2196f3"}}>Up!</strong>
+                            :
+                          this.state.state == 'problems' ?
+                            <strong style={{color: "orange"}}>Problems...</strong>
+                            :
+                            <strong style={{color: "red"}}>Down!</strong>
+                          :
+                          <span>Loading...</span>
+                      }
+                      </td>
+                    </tr>
+                    <tr>
+                      <td colSpan="2"><strong>Public Key</strong></td>
+                    </tr>
+                    <tr>
+                      <td colSpan="2" style={{wordWrap: "break-word"}}>{this.props.data.publicKey}</td>
+                    </tr>
+                  </tbody>
+                </table>
+                <div className="small gray margin-top10">
+                  Checked every 5 mins. Last: {this.props.uptime[0].date} UTC
+                </div>
+              </div>
+              :""
           }
         </Panel>
       </div>

--- a/src/components/Nodes.js
+++ b/src/components/Nodes.js
@@ -24,11 +24,9 @@ export default class Nodes extends React.Component {
 
   render() {
     return (
-      <div className="row">
+      <div className="mui-col-md-12">
         {
-          Object.values(list).map(node => {
-            return <Node key={node.id} data={node} uptime={this.state.uptimeData[node.id]} />
-          })
+          Object.values(list).map(node => <Node key={node.id} data={node} uptime={this.state.uptimeData[node.id]} />)
         }
       </div>
     );

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -241,3 +241,101 @@ section {
 .arc text {
   font-size: 10px;
 }
+
+.node-panel {
+  padding: 0px !important;
+  padding-top: 5px !important;
+  margin-bottom: 5px;
+}
+
+.node-circle-container {
+  display: flex;
+  align-items: center;
+}
+
+.node-circle {
+  width: 10px;
+  height: 10px;
+  border-radius: 100%;
+  padding: 0 !important;
+  margin-right: 10px;
+}
+
+.node-circle.blue {
+  background-color: #2196f3;
+}
+
+.node-circle.orange {
+  background-color: orange;
+}
+
+.node-circle.red {
+  background-color: red;
+}
+
+.node-barchart-container {
+  display: flex;
+  justify-content:flex-end;
+  align-items: center;
+  position: relative;
+}
+
+.node-barchart-container .domain {
+  display: none;
+  visibility: hidden;
+}
+
+.node-barchart {
+  visibility: visible;
+  opacity: 1;
+  transition: all ease-in 100ms;
+}
+
+.node-hovered-container {
+  display: flex;
+  align-items: center;
+  visibility: hidden;
+  z-index: 10;
+  width: 100%;
+  position: absolute;
+  left: 0;
+  transition: all ease-out 100ms;
+}
+
+.node-pubkey {
+  text-align: center;
+  background-color: white;
+  width: 85%;
+  padding-top: 8px;
+}
+
+.node-panel:hover .node-hovered-container {
+  visibility: visible;
+  transition: all ease-in 100ms;
+}
+
+.node-dropdown-button {
+  cursor: pointer;
+}
+
+.node-dropdown {
+  padding: 0px 10px;
+}
+
+@media only screen and (min-width: 400px) and (max-width: 560px) {
+  .node-panel {
+    font-size: 7pt;
+  }
+}
+
+@media only screen and (min-width: 360px) and (max-width: 400px) {
+  .node-panel {
+    font-size: 6pt;
+  }
+}
+
+@media only screen and (max-width: 360px){
+  .node-panel {
+    font-size: 5pt;
+  }
+}

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -244,7 +244,6 @@ section {
 
 .node-panel {
   padding: 0px !important;
-  padding-top: 5px !important;
   margin-bottom: 5px;
 }
 
@@ -286,27 +285,31 @@ section {
 }
 
 .node-barchart {
+  padding-top: 5px;
   visibility: visible;
   opacity: 1;
   transition: all ease-in 100ms;
 }
 
 .node-hovered-container {
-  display: flex;
-  align-items: center;
   visibility: hidden;
   z-index: 10;
   width: 100%;
+  height: 100%;
   position: absolute;
   left: 0;
   transition: all ease-out 100ms;
 }
 
 .node-pubkey {
-  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   background-color: white;
   width: 85%;
-  padding-top: 8px;
+  height: 100%;
+  font-size: 9pt;
+  box-shadow: 5px 0px 7px 0px white;
 }
 
 .node-panel:hover .node-hovered-container {

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -246,6 +246,9 @@ section {
   padding: 0px !important;
   margin-bottom: 5px;
   height: 100%;
+}
+
+.node-panel-large {
   display: flex;
   align-items: center;
 }
@@ -288,10 +291,7 @@ section {
 }
 
 .node-barchart {
-  padding-top: 5px;
-  visibility: visible;
-  opacity: 1;
-  transition: all ease-in 100ms;
+  padding-top: 5px !important;
 }
 
 .node-hovered-container {

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -245,6 +245,9 @@ section {
 .node-panel {
   padding: 0px !important;
   margin-bottom: 5px;
+  height: 100%;
+  display: flex;
+  align-items: center;
 }
 
 .node-circle-container {


### PR DESCRIPTION
*NOTE:* Small view is at 1150 px instead of 768px. Was having issues with responsive sizing and text overlap with public key at smaller values. Also, code may be a little messy -- had some troubles making the table responsive without overlapping text. If there are certain parts to fix, please let me know.

## Full Screen

<img width="1440" alt="screen shot 2018-02-25 at 8 02 13 pm" src="https://user-images.githubusercontent.com/16689974/36653001-3fd99950-1a67-11e8-82c8-bb58d0573eaa.png">


## Full Screen Hover

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/16689974/36653013-50035dc0-1a67-11e8-90ee-819df1363f27.gif)


## Small Screen

<img width="631" alt="screen shot 2018-02-25 at 8 03 34 pm" src="https://user-images.githubusercontent.com/16689974/36653005-440a6e14-1a67-11e8-98ce-19dbfc86c0ea.png">

## Small Screen Expanded View

<img width="641" alt="screen shot 2018-02-25 at 8 03 42 pm" src="https://user-images.githubusercontent.com/16689974/36653011-4ca42858-1a67-11e8-94a2-6fe3464d78b0.png">
