### PR TITLE
Remove protocol 10 news.

### DIFF
--- a/frontend/components/App.js
+++ b/frontend/components/App.js
@@ -108,12 +108,6 @@ export default class App extends React.Component {
       <div id="main" className={this.state.forceTheme ? "force" : null}>
         <AppBar forceTheme={this.state.forceTheme} turnOffForceTheme={this.turnOffForceTheme.bind(this)} />
 
-        <Panel className="mui--bg-accent-light">
-          <div className="mui--text-subhead mui--text-light">
-            The network was upgraded to protocol version 10 on 9/13/2018 @ 4pm UTC. <a href="https://www.reddit.com/r/Stellar/comments/9dkpur/announcement_protocol_10_public_network_rollout/">Read more &raquo;</a>
-          </div>
-        </Panel>
-
         {this.chrome57 ? 
           <Panel>
             <div className="mui--text-subhead mui--text-dark-secondary">


### PR DESCRIPTION
Testnet and Livenet have been updated, so no need for there to be an
announcement at the top of the dashboard.