### PR TITLE
Added COINQVEST Full Validators/History Archives

### DIFF
--- a/common/nodes.js
+++ b/common/nodes.js
@@ -314,4 +314,18 @@ module.exports = [
     port: 11625,
     publicKey: "GDXQB3OMMQ6MGG43PWFBZWBFKBBDUZIVSUDAZZTRAWQZKES2CDSE5HKJ"
   },
+  {
+    id: "coinqvest-fi",
+    name: "COINQVEST (Finland)",
+    host: "finland.stellar.coinqvest.com",
+    port: 11625,
+    publicKey: "GADLA6BJK6VK33EM2IDQM37L5KGVCY5MSHSHVJA4SCNGNUIEOTCR6J5T"
+  },
+  {
+    id: "coinqvest-de",
+    name: "COINQVEST (Germany)",
+    host: "germany.stellar.coinqvest.com",
+    port: 11625,
+    publicKey: "GD6SZQV3WEJUH352NTVLKEV2JM2RH266VPEM7EH5QLLI7ZZAALMLNUVN"
+  }
 ];

--- a/common/nodes.js
+++ b/common/nodes.js
@@ -327,5 +327,5 @@ module.exports = [
     host: "germany.stellar.coinqvest.com",
     port: 11625,
     publicKey: "GD6SZQV3WEJUH352NTVLKEV2JM2RH266VPEM7EH5QLLI7ZZAALMLNUVN"
-  }
+  },
 ];


### PR DESCRIPTION
Hello!

We'd like to add our validators to the list, please. 

You can inspect the state of each validator by viewing the static info URLs (they update every minute):

-> https://finland.stellar.coinqvest.com/info.json
-> https://germany.stellar.coinqvest.com/info.json

The validators run with CATCHUP_COMPLETE=true and we've implemented two public history archives. Information on how to use the archives (along with our quorum configuration) is included in our stellar.toml: 

-> https://www.coinqvest.com/.well-known/stellar.toml

Would it be a good idea to publish a list of known history archives along with the list of known validators on the dashboard and Stellar website in the future? Currently it is hard to find any independent history archives and all new validators basically have to use the SDF ones. Food for thought?

Please let me know anytime if there are questions.

Thanks and have a nice day!

PS: We are COINQVEST and we're here to help online merchants to easily receive and manage crypto payments. We'll be live in 2019.

