### PR TITLE
Fix bottom border color for "ops" on the tx chart

### DIFF
--- a/frontend/components/TransactionsChart.js
+++ b/frontend/components/TransactionsChart.js
@@ -64,7 +64,7 @@ export default class TransactionsChart extends React.Component {
         <Panel>
           <div className="widget-name">
             <span style={{borderBottom: '2px solid #0074B7'}}>Txs
-            </span> &amp; <span style={{borderBottom: '2px solid #0074B7'}}>Op</span><span style={{borderBottom: '2px solid #FF6F00'}}>s</span> in the last {this.props.limit} ledgers: {this.props.network}
+            </span> &amp; <span style={{borderBottom: '2px solid #FF6F00'}}>Ops</span> in the last {this.props.limit} ledgers: {this.props.network}
 
             <a href={this.url} target="_blank" className="api-link">API</a>
           </div>


### PR DESCRIPTION
"OP" in "OPS" is currently underlined as blue, the color for transactions.
Switched the underline on "OPS" over to completely orange, the color for operations.