### PR TITLE
Next testnet reset date (July 2019)

### DIFF
--- a/frontend/components/App.js
+++ b/frontend/components/App.js
@@ -112,7 +112,7 @@ export default class App extends React.Component {
 
         <Panel className="mui--bg-accent-light">
           <div className="mui--text-subhead mui--text-light">
-            The test network will be reset on February 27th, 2019 at 0900 UTC. Please see our <a href="https://www.stellar.org/developers/guides/concepts/test-net.html#best-practices-for-using-testnet">testnet best practices</a> for more information.
+            The test network will be reset on April 24th, 2019 at 0900 UTC. Please see our <a href="https://www.stellar.org/developers/guides/concepts/test-net.html#best-practices-for-using-testnet">testnet best practices</a> for more information.
           </div>
         </Panel>
 

--- a/frontend/components/App.js
+++ b/frontend/components/App.js
@@ -112,7 +112,7 @@ export default class App extends React.Component {
 
         <Panel className="mui--bg-accent-light">
           <div className="mui--text-subhead mui--text-light">
-            The test network will be reset on April 24th, 2019 at 0900 UTC. Please see our <a href="https://www.stellar.org/developers/guides/concepts/test-net.html#best-practices-for-using-testnet">testnet best practices</a> for more information.
+            The test network will be reset on July 31st, 2019 at 0900 UTC. Please see our <a href="https://www.stellar.org/developers/guides/concepts/test-net.html#best-practices-for-using-testnet">testnet best practices</a> for more information.
           </div>
         </Panel>
 


### PR DESCRIPTION
Moving this to July 2019.