### PR TITLE
Use horizon.stellar.org instead of horizon-mon.

### DIFF
--- a/frontend/components/App.js
+++ b/frontend/components/App.js
@@ -20,7 +20,7 @@ import TransactionsChart from "./TransactionsChart";
 import FailedTransactionsChart from "./FailedTransactionsChart";
 import { LIVE_NEW_LEDGER, TEST_NEW_LEDGER } from "../events";
 
-const horizonLive = "https://horizon-mon.stellar-ops.com";
+const horizonLive = "https://horizon.stellar.org";
 const horizonTest = "https://horizon-testnet.stellar.org";
 
 export default class App extends React.Component {


### PR DESCRIPTION
We''ll be deploying Horizon 1.0.0 to horizon-mon soon and it could incorrectly display the network as down while it reingests state.

Let's use horizon.stellar.org for now and then we'll switch it back once we have successfully deployed 1.0.0 to mon.