### PR TITLE
Use horizon.stellar.org instead of horizon-mon.stellar-ops.com

### DIFF
--- a/frontend/components/App.js
+++ b/frontend/components/App.js
@@ -22,7 +22,7 @@ import { LIVE_NEW_LEDGER, TEST_NEW_LEDGER } from "../events";
 import { setTimeOffset } from "../common/time";
 import { ScheduledMaintenance } from "./ScheduledMaintenance";
 
-const horizonLive = "https://horizon-mon.stellar-ops.com";
+const horizonLive = "https://horizon.stellar.org";
 const horizonTest = "https://horizon-testnet.stellar.org";
 
 export default class App extends React.Component {


### PR DESCRIPTION
I talked with the ops team and horizon-mon.stellar-ops.com is used only in the Dashboard now. Since we have a public horizon.stellar.org cluster there is no point in maintaining horizon-mon.stellar-ops.com.