### PR TITLE
Make XLM balance calc resilient to deleted accounts

### DIFF
--- a/common/lumens.js
+++ b/common/lumens.js
@@ -61,7 +61,7 @@ export function getLumenBalance(horizonURL, accountId) {
     })
     .catch((error) => {
       if (error.response && error.response.status == 404) {
-        return "0.0"; // disconsider the balance of an account if there's an error with the request
+        return "0.0"; // consider the balance of an account zero if the account does not exist or has been deleted from the network
       } else throw error; // something else happened, and at this point we shouldn't trust the computed balance
     });
 }

--- a/common/lumens.js
+++ b/common/lumens.js
@@ -50,13 +50,20 @@ const accounts = {
 export const ORIGINAL_SUPPLY_AMOUNT = "100000000000";
 
 export function getLumenBalance(horizonURL, accountId) {
-  return axios.get(`${horizonURL}/accounts/${accountId}`).then((response) => {
-    var xlmBalance = find(
-      response.data.balances,
-      (b) => b.asset_type == "native",
-    );
-    return xlmBalance.balance;
-  });
+  return axios
+    .get(`${horizonURL}/accounts/${accountId}`)
+    .then((response) => {
+      var xlmBalance = find(
+        response.data.balances,
+        (b) => b.asset_type == "native",
+      );
+      return xlmBalance.balance;
+    })
+    .catch((error) => {
+      if (error.response && error.response.status == 404) {
+        return "0.0"; // disconsider the balance of an account if there's an error with the request
+      } else throw error; // something else happened, and at this point we shouldn't trust the computed balance
+    });
 }
 
 function sumRelevantAccounts(accounts) {


### PR DESCRIPTION
## What?

Whenever computing the XLM supplies, if an account has been deleted, we should still be able to compute the overall number without errors.

## Why? 
When checking for the info of an account that has been deleted via Horizon, you get a 404 response. This is interpreted by axios as an error, and we should be able to handle that error gracefully (as a deleted account should simply be considered as having a zero XLM balance).