### PR TITLE
{backend, common}: open new total-supply-check endpoint

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -33,15 +33,17 @@ if (process.env.DEV) {
 
 app.get("/api/ledgers/public", ledgers.handler);
 app.get("/api/lumens", lumens.handler);
-app.get("/api/v2/lumens", lumensV2.handler);
 
+app.get("/api/v2/lumens", lumensV2.handler);
 /* For CoinMarketCap */
 app.get("/api/v2/lumens/total-supply", lumensV2.totalSupplyHandler);
 app.get("/api/v2/lumens/circulating-supply", lumensV2.circulatingSupplyHandler);
 
+app.get("/api/v3/lumens", lumensV3.handler);
 app.get("/api/v3/lumens/total-supply-check", lumensV3.totalSupplySumHandler);
-app.get("/api/v3/lumens/circulating-supply", lumensV3.circulatingSupplyHandler);
+/* For CoinMarketCap */
 app.get("/api/v3/lumens/total-supply", lumensV3.totalSupplyHandler);
+app.get("/api/v3/lumens/circulating-supply", lumensV3.circulatingSupplyHandler);
 
 app.listen(app.get("port"), function() {
   console.log("Listening on port", app.get("port"));

--- a/backend/app.js
+++ b/backend/app.js
@@ -4,6 +4,7 @@ import logger from "morgan";
 
 import * as lumens from "./lumens.js";
 import * as lumensV2 from "./v2/lumens.js";
+import * as lumensV3 from "./v3/lumens.js";
 import * as ledgers from "./ledgers.js";
 
 var app = express();
@@ -38,13 +39,9 @@ app.get("/api/v2/lumens", lumensV2.handler);
 app.get("/api/v2/lumens/total-supply", lumensV2.totalSupplyHandler);
 app.get("/api/v2/lumens/circulating-supply", lumensV2.circulatingSupplyHandler);
 
-app.get("/api/v2/lumens/total-supply-check", lumensV2.totalSupplySumHandler);
+app.get("/api/v3/lumens/total-supply-check", lumensV3.totalSupplySumHandler);
 
-// Temporary endpoint, returning string instead of number for precision
-app.get(
-  "/api/v2/lumens/total-supply-full",
-  lumensV2.totalSupplyFullDataHandler,
-);
+app.get("/api/v3/lumens/total-supply", lumensV3.totalSupplyDataHandler);
 
 app.listen(app.get("port"), function() {
   console.log("Listening on port", app.get("port"));

--- a/backend/app.js
+++ b/backend/app.js
@@ -41,7 +41,7 @@ app.get("/api/v2/lumens/circulating-supply", lumensV2.circulatingSupplyHandler);
 
 app.get("/api/v3/lumens/total-supply-check", lumensV3.totalSupplySumHandler);
 app.get("/api/v3/lumens/circulating-supply", lumensV3.circulatingSupplyHandler);
-app.get("/api/v3/lumens/total-supply", lumensV3.totalSupplyDataHandler);
+app.get("/api/v3/lumens/total-supply", lumensV3.totalSupplyHandler);
 
 app.listen(app.get("port"), function() {
   console.log("Listening on port", app.get("port"));

--- a/backend/app.js
+++ b/backend/app.js
@@ -40,6 +40,12 @@ app.get("/api/v2/lumens/circulating-supply", lumensV2.circulatingSupplyHandler);
 
 app.get("/api/v2/lumens/total-supply-check", lumensV2.totalSupplySumHandler);
 
+// Temporary endpoint, returning string instead of number for precision
+app.get(
+  "/api/v2/lumens/total-supply-full",
+  lumensV2.totalSupplyFullDataHandler,
+);
+
 app.listen(app.get("port"), function() {
   console.log("Listening on port", app.get("port"));
 });

--- a/backend/app.js
+++ b/backend/app.js
@@ -38,6 +38,8 @@ app.get("/api/v2/lumens", lumensV2.handler);
 app.get("/api/v2/lumens/total-supply", lumensV2.totalSupplyHandler);
 app.get("/api/v2/lumens/circulating-supply", lumensV2.circulatingSupplyHandler);
 
+app.get("/api/v2/lumens/total-supply-check", lumensV2.totalSupplySumHandler);
+
 app.listen(app.get("port"), function() {
   console.log("Listening on port", app.get("port"));
 });

--- a/backend/app.js
+++ b/backend/app.js
@@ -40,7 +40,6 @@ app.get("/api/v2/lumens/total-supply", lumensV2.totalSupplyHandler);
 app.get("/api/v2/lumens/circulating-supply", lumensV2.circulatingSupplyHandler);
 
 app.get("/api/v3/lumens/total-supply-check", lumensV3.totalSupplySumHandler);
-
 app.get("/api/v3/lumens/total-supply", lumensV3.totalSupplyDataHandler);
 
 app.listen(app.get("port"), function() {

--- a/backend/app.js
+++ b/backend/app.js
@@ -40,6 +40,7 @@ app.get("/api/v2/lumens/total-supply", lumensV2.totalSupplyHandler);
 app.get("/api/v2/lumens/circulating-supply", lumensV2.circulatingSupplyHandler);
 
 app.get("/api/v3/lumens/total-supply-check", lumensV3.totalSupplySumHandler);
+app.get("/api/v3/lumens/circulating-supply", lumensV3.circulatingSupplyHandler);
 app.get("/api/v3/lumens/total-supply", lumensV3.totalSupplyDataHandler);
 
 app.listen(app.get("port"), function() {

--- a/backend/v2/lumens.js
+++ b/backend/v2/lumens.js
@@ -8,9 +8,6 @@ const LUMEN_SUPPLY_METRICS_URL =
 let totalSupplyData;
 let circulatingSupplyData;
 
-let totalSupplySumData;
-let totalSupplyFullData;
-
 export const handler = function(req, res) {
   res.send(cachedData);
 };
@@ -23,14 +20,6 @@ export const circulatingSupplyHandler = function(req, res) {
   res.json(circulatingSupplyData);
 };
 
-export const totalSupplySumHandler = function(req, res) {
-  res.json(totalSupplySumData);
-};
-
-export const totalSupplyFullDataHandler = function(req, res) {
-  res.json(totalSupplyFullData);
-};
-
 function updateApiLumens() {
   Promise.all([
     commonLumens.ORIGINAL_SUPPLY_AMOUNT,
@@ -41,7 +30,6 @@ function updateApiLumens() {
     commonLumens.feePool(),
     commonLumens.sdfAccounts(),
     commonLumens.circulatingSupply(),
-    commonLumens.totalSupplySum(),
   ])
     .then(function([
       originalSupply,
@@ -52,7 +40,6 @@ function updateApiLumens() {
       feePool,
       sdfMandate,
       circulatingSupply,
-      totalSupplySum,
     ]) {
       var response = {
         updatedAt: new Date(),
@@ -72,10 +59,6 @@ function updateApiLumens() {
       /* For CoinMarketCap */
       totalSupplyData = response.totalSupply * 1;
       circulatingSupplyData = response.circulatingSupply * 1;
-
-      totalSupplySumData = totalSupplySum.toString();
-
-      totalSupplyFullData = response.totalSupply.toString();
 
       console.log("/api/lumens data saved!");
     })

--- a/backend/v2/lumens.js
+++ b/backend/v2/lumens.js
@@ -65,10 +65,10 @@ function updateApiLumens() {
       cachedData = response;
 
       /* For CoinMarketCap */
-      totalSupplyData = response.totalSupply * 1;
-      circulatingSupplyData = response.circulatingSupply * 1;
+      totalSupplyData = response.totalSupply.toString();
+      circulatingSupplyData = response.circulatingSupply.toString();
 
-      totalSupplySumData = totalSupplySum * 1;
+      totalSupplySumData = totalSupplySum.toString();
 
       console.log("/api/lumens data saved!");
     })

--- a/backend/v2/lumens.js
+++ b/backend/v2/lumens.js
@@ -9,6 +9,7 @@ let totalSupplyData;
 let circulatingSupplyData;
 
 let totalSupplySumData;
+let totalSupplyFullData;
 
 export const handler = function(req, res) {
   res.send(cachedData);
@@ -24,6 +25,10 @@ export const circulatingSupplyHandler = function(req, res) {
 
 export const totalSupplySumHandler = function(req, res) {
   res.json(totalSupplySumData);
+};
+
+export const totalSupplyFullDataHandler = function(req, res) {
+  res.json(totalSupplyFullData);
 };
 
 function updateApiLumens() {
@@ -65,10 +70,12 @@ function updateApiLumens() {
       cachedData = response;
 
       /* For CoinMarketCap */
-      totalSupplyData = response.totalSupply.toString();
-      circulatingSupplyData = response.circulatingSupply.toString();
+      totalSupplyData = response.totalSupply * 1;
+      circulatingSupplyData = response.circulatingSupply * 1;
 
       totalSupplySumData = totalSupplySum.toString();
+
+      totalSupplyFullData = response.totalSupply.toString();
 
       console.log("/api/lumens data saved!");
     })

--- a/backend/v2/lumens.js
+++ b/backend/v2/lumens.js
@@ -8,6 +8,8 @@ const LUMEN_SUPPLY_METRICS_URL =
 let totalSupplyData;
 let circulatingSupplyData;
 
+let totalSupplySumData;
+
 export const handler = function(req, res) {
   res.send(cachedData);
 };
@@ -20,6 +22,10 @@ export const circulatingSupplyHandler = function(req, res) {
   res.json(circulatingSupplyData);
 };
 
+export const totalSupplySumHandler = function(req, res) {
+  res.json(totalSupplySumData);
+};
+
 function updateApiLumens() {
   Promise.all([
     commonLumens.ORIGINAL_SUPPLY_AMOUNT,
@@ -30,6 +36,7 @@ function updateApiLumens() {
     commonLumens.feePool(),
     commonLumens.sdfAccounts(),
     commonLumens.circulatingSupply(),
+    commonLumens.totalSupplySum(),
   ])
     .then(function([
       originalSupply,
@@ -40,6 +47,7 @@ function updateApiLumens() {
       feePool,
       sdfMandate,
       circulatingSupply,
+      totalSupplySum,
     ]) {
       var response = {
         updatedAt: new Date(),
@@ -59,6 +67,8 @@ function updateApiLumens() {
       /* For CoinMarketCap */
       totalSupplyData = response.totalSupply * 1;
       circulatingSupplyData = response.circulatingSupply * 1;
+
+      totalSupplySumData = totalSupplySum * 1;
 
       console.log("/api/lumens data saved!");
     })

--- a/backend/v3/lumens.js
+++ b/backend/v3/lumens.js
@@ -5,7 +5,7 @@ let totalSupplyData;
 let circulatingSupplyData;
 let totalSupplySumData;
 
-export const totalSupplyDataHandler = function(req, res) {
+export const totalSupplyHandler = function(req, res) {
   res.json(totalSupplyData);
 };
 

--- a/backend/v3/lumens.js
+++ b/backend/v3/lumens.js
@@ -2,10 +2,15 @@ import * as commonLumens from "../../common/lumens.js";
 import BigNumber from "bignumber.js";
 
 let totalSupplyData;
+let circulatingSupplyData;
 let totalSupplySumData;
 
 export const totalSupplyDataHandler = function(req, res) {
   res.json(totalSupplyData);
+};
+
+export const circulatingSupplyHandler = function(req, res) {
+  res.json(circulatingSupplyData);
 };
 
 export const totalSupplySumHandler = function(req, res) {
@@ -13,9 +18,14 @@ export const totalSupplySumHandler = function(req, res) {
 };
 
 function updateApiLumens() {
-  Promise.all([commonLumens.totalSupply(), commonLumens.totalSupplySum()])
-    .then(function([totalSupply, totalSupplySum]) {
+  Promise.all([
+    commonLumens.totalSupply(),
+    commonLumens.totalSupplySum(),
+    commonLumens.circulatingSupply(),
+  ])
+    .then(function([totalSupply, totalSupplySum, circulatingSupply]) {
       totalSupplyData = totalSupply.toString();
+      circulatingSupplyData = circulatingSupply.toString();
       totalSupplySumData = totalSupplySum.toString();
 
       console.log("/api/lumens data saved!");

--- a/backend/v3/lumens.js
+++ b/backend/v3/lumens.js
@@ -1,9 +1,19 @@
 import * as commonLumens from "../../common/lumens.js";
 import BigNumber from "bignumber.js";
 
+let cachedData;
+const LUMEN_SUPPLY_METRICS_URL =
+  "https://www.stellar.org/developers/guides/lumen-supply-metrics.html";
+
+/* For CoinMarketCap */
 let totalSupplyData;
 let circulatingSupplyData;
+
 let totalSupplySumData;
+
+export const handler = function(req, res) {
+  res.send(cachedData);
+};
 
 export const totalSupplyHandler = function(req, res) {
   res.json(totalSupplyData);
@@ -19,11 +29,42 @@ export const totalSupplySumHandler = function(req, res) {
 
 function updateApiLumens() {
   Promise.all([
+    commonLumens.ORIGINAL_SUPPLY_AMOUNT,
+    commonLumens.inflationLumens(),
+    commonLumens.burnedLumens(),
     commonLumens.totalSupply(),
-    commonLumens.totalSupplySum(),
+    commonLumens.getUpgradeReserve(),
+    commonLumens.feePool(),
+    commonLumens.sdfAccounts(),
     commonLumens.circulatingSupply(),
+    commonLumens.totalSupplySum(),
   ])
-    .then(function([totalSupply, totalSupplySum, circulatingSupply]) {
+    .then(function([
+      originalSupply,
+      inflationLumens,
+      burnedLumens,
+      totalSupply,
+      upgradeReserve,
+      feePool,
+      sdfMandate,
+      circulatingSupply,
+      totalSupplySum,
+    ]) {
+      var response = {
+        updatedAt: new Date(),
+        originalSupply,
+        inflationLumens,
+        burnedLumens,
+        totalSupply,
+        upgradeReserve,
+        feePool,
+        sdfMandate,
+        circulatingSupply,
+        _details: LUMEN_SUPPLY_METRICS_URL,
+      };
+
+      cachedData = response;
+
       totalSupplyData = totalSupply.toString();
       circulatingSupplyData = circulatingSupply.toString();
       totalSupplySumData = totalSupplySum.toString();

--- a/backend/v3/lumens.js
+++ b/backend/v3/lumens.js
@@ -1,0 +1,30 @@
+import * as commonLumens from "../../common/lumens.js";
+import BigNumber from "bignumber.js";
+
+let totalSupplyData;
+let totalSupplySumData;
+
+export const totalSupplyDataHandler = function(req, res) {
+  res.json(totalSupplyData);
+};
+
+export const totalSupplySumHandler = function(req, res) {
+  res.json(totalSupplySumData);
+};
+
+function updateApiLumens() {
+  Promise.all([commonLumens.totalSupply(), commonLumens.totalSupplySum()])
+    .then(function([totalSupply, totalSupplySum]) {
+      totalSupplyData = totalSupply.toString();
+      totalSupplySumData = totalSupplySum.toString();
+
+      console.log("/api/lumens data saved!");
+    })
+    .catch(function(err) {
+      console.error(err);
+      res.sendStatus(500);
+    });
+}
+
+setInterval(updateApiLumens, 10 * 60 * 1000);
+updateApiLumens();

--- a/common/lumens.js
+++ b/common/lumens.js
@@ -227,11 +227,11 @@ export function totalSupplySum() {
     feePool(),
     sdfAccounts(),
     circulatingSupply(),
-  ]).then((balances) => {
-    return reduce(
-      balances,
-      (sum, balance) => sum.add(balance),
-      new BigNumber(0),
-    );
+  ]).then((result) => {
+    let [upgradeReserve, feePool, sdfAccounts, circulatingSupply] = result;
+    return new BigNumber(upgradeReserve)
+      .plus(feePool)
+      .plus(sdfAccounts)
+      .plus(circulatingSupply);
   });
 }

--- a/common/lumens.js
+++ b/common/lumens.js
@@ -220,3 +220,18 @@ export function circulatingSupply() {
     return new BigNumber(totalLumens).minus(noncirculatingSupply);
   });
 }
+
+export function totalSupplySum() {
+  return Promise.all([
+    getUpgradeReserve(),
+    feePool(),
+    sdfAccounts(),
+    circulatingSupply(),
+  ]).then((balances) => {
+    return reduce(
+      balances,
+      (sum, balance) => sum.add(balance),
+      new BigNumber(0),
+    );
+  });
+}


### PR DESCRIPTION
**WHAT**
adds a new endpoint `/api/v3/lumens/total-supply-check`. This endpoint returns the sum of:
`upgrade_reserve + fee_pool + sdf_mandate + circulating_supply`

also adds a new endpoint `/api/v3/lumens/total-supply`. The v2 version of this endpoint returned the value as a Number, which would lose a decimal point of precision. So the v3 endpoints return as strings

**WHY**
right now Blazemeter is using dashboard endpoints for the [Total Lumens check](https://www.runscope.com/radar/v60ug3n4szv3/c5acd368-d46c-4a9f-a5f5-4f08f96fbe6e). In that check we're using the JS `parseFloat` and `parseInt` methods, which lose precision when the number is larger than what js `Number` can handle.

By returning this new endpoint, Blazemeter only has to compare `/api/v3/lumens/total-supply` to `/api/v3/lumens/total-supply-check`, so it doesn't have to do any parsing/multiplication on its end. And all values are handled by `BigNumber` on the dashboard side. Which is good because Blazemeter has limited [library support](https://guide.blazemeter.com/hc/en-us/articles/360001858778).


closes https://github.com/stellar/dashboard/issues/181

note: the original request was for returning whole numbers. I think this solution is better for the reason stated above that Blazemeter would not be able to handle the whole number anyways since `parseInt` would lose precision. So comparing the strings directly instead should be more accurate.