### PR TITLE
backend: use single endpoint for checking total supply

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -40,7 +40,7 @@ app.get("/api/v2/lumens/total-supply", lumensV2.totalSupplyHandler);
 app.get("/api/v2/lumens/circulating-supply", lumensV2.circulatingSupplyHandler);
 
 app.get("/api/v3/lumens", lumensV3.handler);
-app.get("/api/v3/lumens/total-supply-check", lumensV3.totalSupplyCheckHandler);
+app.get("/api/v3/lumens/all", lumensV3.totalSupplyCheckHandler);
 /* For CoinMarketCap */
 app.get("/api/v3/lumens/total-supply", lumensV3.totalSupplyHandler);
 app.get("/api/v3/lumens/circulating-supply", lumensV3.circulatingSupplyHandler);

--- a/backend/app.js
+++ b/backend/app.js
@@ -40,7 +40,7 @@ app.get("/api/v2/lumens/total-supply", lumensV2.totalSupplyHandler);
 app.get("/api/v2/lumens/circulating-supply", lumensV2.circulatingSupplyHandler);
 
 app.get("/api/v3/lumens", lumensV3.handler);
-app.get("/api/v3/lumens/total-supply-check", lumensV3.totalSupplySumHandler);
+app.get("/api/v3/lumens/total-supply-check", lumensV3.totalSupplyCheckHandler);
 /* For CoinMarketCap */
 app.get("/api/v3/lumens/total-supply", lumensV3.totalSupplyHandler);
 app.get("/api/v3/lumens/circulating-supply", lumensV3.circulatingSupplyHandler);

--- a/backend/v3/lumens.js
+++ b/backend/v3/lumens.js
@@ -65,6 +65,7 @@ function updateApiLumens() {
 
       cachedData = response;
 
+      totalSupplyData = totalSupply.toString();
       circulatingSupplyData = circulatingSupply.toString();
 
       totalSupplyCheckResponse = {

--- a/backend/v3/lumens.js
+++ b/backend/v3/lumens.js
@@ -9,7 +9,7 @@ const LUMEN_SUPPLY_METRICS_URL =
 let totalSupplyData;
 let circulatingSupplyData;
 
-let totalSupplySumData;
+let totalSupplyCheckResponse;
 
 export const handler = function(req, res) {
   res.send(cachedData);
@@ -23,8 +23,8 @@ export const circulatingSupplyHandler = function(req, res) {
   res.json(circulatingSupplyData);
 };
 
-export const totalSupplySumHandler = function(req, res) {
-  res.json(totalSupplySumData);
+export const totalSupplyCheckHandler = function(req, res) {
+  res.json(totalSupplyCheckResponse);
 };
 
 function updateApiLumens() {
@@ -65,9 +65,19 @@ function updateApiLumens() {
 
       cachedData = response;
 
-      totalSupplyData = totalSupply.toString();
       circulatingSupplyData = circulatingSupply.toString();
-      totalSupplySumData = totalSupplySum.toString();
+
+      totalSupplyCheckResponse = {
+        updatedAt: new Date(),
+        totalSupply: totalSupply.toString(),
+        inflationLumens,
+        burnedLumens,
+        totalSupplySum: totalSupplySum.toString(),
+        upgradeReserve,
+        feePool,
+        sdfMandate,
+        circulatingSupply,
+      };
 
       console.log("/api/lumens data saved!");
     })
@@ -77,5 +87,5 @@ function updateApiLumens() {
     });
 }
 
-setInterval(updateApiLumens, 10 * 60 * 1000);
+setInterval(updateApiLumens, 1 * 60 * 1000);
 updateApiLumens();


### PR DESCRIPTION
**WHAT**
uses a single endpoint to check the total supply values instead of 2

**WHY**
the Runscope alert is still throwing errors. The cause may be due to Runscope calling 2 endpoints separately causing a race condition.
(more context here: https://stellarfoundation.slack.com/archives/CANJGG94K/p1636975310074200)