### PR TITLE
{backend, common}: compute the derived values from updateApiLumens

### DIFF
--- a/backend/v3/lumens.js
+++ b/backend/v3/lumens.js
@@ -90,5 +90,5 @@ function updateApiLumens() {
     });
 }
 
-setInterval(updateApiLumens, 8 * 1000);
+setInterval(updateApiLumens, 1 * 60 * 1000);
 updateApiLumens();

--- a/backend/v3/lumens.js
+++ b/backend/v3/lumens.js
@@ -40,8 +40,7 @@ function updateApiLumens() {
       upgradeReserve,
       sdfMandate,
     ]) {
-      let totalSupply = new BigNumber(0)
-        .plus(originalSupply)
+      let totalSupply = new BigNumber(originalSupply)
         .plus(inflationLumens)
         .minus(burnedLumens);
 

--- a/backend/v3/lumens.js
+++ b/backend/v3/lumens.js
@@ -5,26 +5,22 @@ let cachedData;
 const LUMEN_SUPPLY_METRICS_URL =
   "https://www.stellar.org/developers/guides/lumen-supply-metrics.html";
 
-/* For CoinMarketCap */
-let totalSupplyData;
-let circulatingSupplyData;
-
 let totalSupplyCheckResponse;
 
 export const handler = function(req, res) {
   res.send(cachedData);
 };
 
-export const totalSupplyHandler = function(req, res) {
-  res.json(totalSupplyData);
-};
-
-export const circulatingSupplyHandler = function(req, res) {
-  res.json(circulatingSupplyData);
-};
-
 export const totalSupplyCheckHandler = function(req, res) {
   res.json(totalSupplyCheckResponse);
+};
+
+/* For CoinMarketCap */
+export const totalSupplyHandler = function(req, res) {
+  res.json(totalSupplyCheckResponse.totalSupplySum);
+};
+export const circulatingSupplyHandler = function(req, res) {
+  res.json(totalSupplyCheckResponse.circulatingSupply);
 };
 
 function updateApiLumens() {
@@ -32,25 +28,34 @@ function updateApiLumens() {
     commonLumens.ORIGINAL_SUPPLY_AMOUNT,
     commonLumens.inflationLumens(),
     commonLumens.burnedLumens(),
-    commonLumens.totalSupply(),
-    commonLumens.getUpgradeReserve(),
     commonLumens.feePool(),
+    commonLumens.getUpgradeReserve(),
     commonLumens.sdfAccounts(),
-    commonLumens.circulatingSupply(),
-    commonLumens.totalSupplySum(),
   ])
     .then(function([
       originalSupply,
       inflationLumens,
       burnedLumens,
-      totalSupply,
-      upgradeReserve,
       feePool,
+      upgradeReserve,
       sdfMandate,
-      circulatingSupply,
-      totalSupplySum,
     ]) {
-      var response = {
+      let totalSupply = new BigNumber(0)
+        .plus(originalSupply)
+        .plus(inflationLumens)
+        .minus(burnedLumens);
+
+      let circulatingSupply = totalSupply
+        .minus(upgradeReserve)
+        .minus(feePool)
+        .minus(sdfMandate);
+
+      let totalSupplySum = circulatingSupply
+        .plus(upgradeReserve)
+        .plus(feePool)
+        .plus(sdfMandate);
+
+      let response = {
         updatedAt: new Date(),
         originalSupply,
         inflationLumens,
@@ -65,15 +70,12 @@ function updateApiLumens() {
 
       cachedData = response;
 
-      totalSupplyData = totalSupply.toString();
-      circulatingSupplyData = circulatingSupply.toString();
-
       totalSupplyCheckResponse = {
         updatedAt: new Date(),
-        totalSupply: totalSupply.toString(),
+        totalSupply,
         inflationLumens,
         burnedLumens,
-        totalSupplySum: totalSupplySum.toString(),
+        totalSupplySum,
         upgradeReserve,
         feePool,
         sdfMandate,
@@ -88,5 +90,5 @@ function updateApiLumens() {
     });
 }
 
-setInterval(updateApiLumens, 1 * 60 * 1000);
+setInterval(updateApiLumens, 8 * 1000);
 updateApiLumens();

--- a/common/lumens.js
+++ b/common/lumens.js
@@ -220,18 +220,3 @@ export function circulatingSupply() {
     return new BigNumber(totalLumens).minus(noncirculatingSupply);
   });
 }
-
-export function totalSupplySum() {
-  return Promise.all([
-    getUpgradeReserve(),
-    feePool(),
-    sdfAccounts(),
-    circulatingSupply(),
-  ]).then((result) => {
-    let [upgradeReserve, feePool, sdfAccounts, circulatingSupply] = result;
-    return new BigNumber(upgradeReserve)
-      .plus(feePool)
-      .plus(sdfAccounts)
-      .plus(circulatingSupply);
-  });
-}


### PR DESCRIPTION
**WHAT**
change the derived values (totalSupply, circulatingSupply, totalSupplySum) to be computed in the updateApiLumens method, instead of the promises returned from common.

**WHY**
the derived values each call Horizon on their own (eg. `totalSupplySum` calls `feePool` and `circulatingSupply` calls `feePool` through `nonCirculatingSupply`). The promises calling Horizon on their own create a race condition, which is causing an error when testing that the values are the same with Runscope. So instead, calculate the values in the final method instead, so each Horizon endpoint is called just once.

<hr>

Also:
In this PR you can see that `totalSupply` will always equal `totalSupplySum` (if you plug in circulatingSupply to the totalSupplySum equation). So currently Dashboard is just checking for the race condition that I'm removing now, since how Dashboard computes `circulatingSupply` is derived from `totalSupply`. So, for checking that `totalSupply` is correct, I think we should use Hubble. That should be a pretty simple query in hubble to get the `circulatingSupply`.

@satyamz said that Runscope previously was using the `core-mon-api` [`/accounts' endpoint](https://github.com/stellar/core-mon-api/blob/983a9765f36c0d3e47354232549ffac4a1465b52/index.js#L22-L34), which was querying all of the  accounts w/ lumens and signers. Dashboard can't make this kind of request.

Alternatively, dashboard can call Horizon's [totalCoins](https://horizon.stellar.org/ledgers/?order=desc&limit=1) endpoint and subtract the `inflationAccount` lumens, to make sure it's always equal to 1B xlm.

Lmk what you think @accordeiro @leighmcculloch 







