### PR TITLE
backend: make cache update methods wait

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -49,10 +49,10 @@ app.listen(app.get("port"), function() {
   console.log("Listening on port", app.get("port"));
 });
 
-export function updateLumensCache() {
-  lumens.updateApiLumens();
-  lumensV2.updateApiLumens();
-  lumensV3.updateApiLumens();
+export async function updateLumensCache() {
+  await lumens.updateApiLumens();
+  await lumensV2.updateApiLumens();
+  await lumensV3.updateApiLumens();
 }
 setInterval(updateLumensCache, 10 * 60 * 1000);
 updateLumensCache();


### PR DESCRIPTION
**WHAT**
make the cache update calls synchronous

**WHY**
there's 3 versions of the `updateApiLumens` method being called simultaneously, and each hits Horizon multiple times. This is causing a 429 error with Horizon. So make each one wait for the other. The calls are quick so they don't wait long.

note: looking at kibana each version of the api is being called (last I looked at least ~1000 a month each), so can't deprecate versions atm