### PR TITLE
backend: adding integration tests

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,5 +1,10 @@
 name: Test and build
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/app.js
+++ b/app.js
@@ -2,4 +2,8 @@ require("babel-register")({
   presets: ["es2015"],
 });
 
-require("./backend/app.js");
+// Run backend with interval cache updates.
+const { updateLumensCache } = require("./backend/app.js");
+
+setInterval(updateLumensCache, 10 * 60 * 1000);
+updateLumensCache();

--- a/backend/app.js
+++ b/backend/app.js
@@ -6,7 +6,7 @@ import * as lumens from "./lumens.js";
 import * as lumensV2V3 from "./v2v3/lumens.js";
 import * as ledgers from "./ledgers.js";
 
-var app = express();
+export var app = express();
 app.set("port", process.env.PORT || 5000);
 app.set("json spaces", 2);
 

--- a/backend/app.js
+++ b/backend/app.js
@@ -58,5 +58,3 @@ export async function updateLumensCache() {
   await lumens.updateApiLumens();
   await lumensV2V3.updateApiLumens();
 }
-setInterval(updateLumensCache, 10 * 60 * 1000);
-updateLumensCache();

--- a/backend/ledgers.js
+++ b/backend/ledgers.js
@@ -9,7 +9,7 @@ export const handler = function(req, res) {
   res.send(cachedData);
 };
 
-function updateResults() {
+export async function updateResults() {
   let query = `select
       to_char(closed_at, 'YYYY-MM-DD') as date,
       sum(transaction_count) as transaction_count,

--- a/backend/ledgers.js
+++ b/backend/ledgers.js
@@ -9,7 +9,7 @@ export const handler = function(req, res) {
   res.send(cachedData);
 };
 
-export async function updateResults() {
+function updateResults() {
   let query = `select
       to_char(closed_at, 'YYYY-MM-DD') as date,
       sum(transaction_count) as transaction_count,

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "sequelize": "^5.3.0",
     "stellar-sdk": "^2.0.0-beta.7",
     "style-loader": "^0.19.0",
-    "supertest": "^6.1.6",
     "webpack": "^1.13.3"
   },
   "devDependencies": {
@@ -73,6 +72,7 @@
     "husky": "1.3.1",
     "lint-staged": "7.3.0",
     "mocha": "^8.4.0",
-    "prettier": "^1.18.2"
+    "prettier": "^1.18.2",
+    "supertest": "^6.1.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "gulp build",
     "heroku-postbuild": "gulp build",
     "lint:prettier": "prettier --config --write '**/*.js'",
-    "test": "mocha './test/**/*.js'"
+    "test": "DEV=true mocha './test/**/*.js' --exit"
   },
   "husky": {
     "hooks": {
@@ -65,13 +65,14 @@
     "sequelize": "^5.3.0",
     "stellar-sdk": "^2.0.0-beta.7",
     "style-loader": "^0.19.0",
+    "supertest": "^6.1.6",
     "webpack": "^1.13.3"
   },
   "devDependencies": {
+    "chai": "^4.3.4",
     "husky": "1.3.1",
     "lint-staged": "7.3.0",
-    "prettier": "^1.18.2",
-    "chai": "^4.3.4",
-    "mocha": "^8.4.0"
+    "mocha": "^8.4.0",
+    "prettier": "^1.18.2"
   }
 }

--- a/test/tests/integration/backend.js
+++ b/test/tests/integration/backend.js
@@ -2,22 +2,15 @@ import chai from "chai";
 const request = require("supertest");
 
 const { app, updateLumensCache } = require("../../../backend/app.js");
-const { updateResults, cachedData } = require("../../../backend/ledgers.js");
-
 describe("integration", function() {
   // update caches
   before(async function() {
     await updateLumensCache();
-    await updateResults();
   });
 
   describe("backend api endpoints", function() {
     it("should return data of correct type", async function() {
       let testCases = [
-        {
-          url: "/api/ledgers/public",
-          wantResultType: "array",
-        },
         {
           url: "/api/lumens",
           wantResultType: "object",

--- a/test/tests/integration/backend.js
+++ b/test/tests/integration/backend.js
@@ -9,62 +9,76 @@ describe("integration", function() {
   });
 
   describe("backend api endpoints", function() {
-    it("should return data of correct type", async function() {
-      let testCases = [
-        {
-          url: "/api/lumens",
-          wantResultType: "object",
-        },
-        {
-          url: "/api/v2/lumens",
-          wantResultType: "object",
-        },
-        {
-          url: "/api/v2/lumens/total-supply",
-          wantResultType: "number",
-        },
-        {
-          url: "/api/v2/lumens/circulating-supply",
-          wantResultType: "number",
-        },
-        { url: "/api/v3/lumens", wantResultType: "object" },
-        { url: "/api/v3/lumens/all", wantResultType: "object" },
-        {
-          url: "/api/v3/lumens/total-supply",
-          wantResultType: "string",
-        },
-        {
-          url: "/api/v3/lumens/circulating-supply",
-          wantResultType: "string",
-        },
-      ];
+    it("/api/lumens should return successfuly with data", async function() {
+      let { body } = await request(app)
+        .get("/api/lumens")
+        .expect(200);
 
-      for (var tc of testCases) {
-        console.log("testing: ", tc.url);
-        let { body } = await request(app)
-          .get(tc.url)
-          .expect(200);
+      chai.expect(body).to.be.an("object");
+      chai.expect(Object.keys(body).length).to.not.equal(0);
+    });
 
-        chai.expect(body).to.be.an(tc.wantResultType);
-        chai.expect(containsData(body)).to.be.true;
-      }
+    it("/api/v2/lumens should return successfuly with data", async function() {
+      let { body } = await request(app)
+        .get("/api/v2/lumens")
+        .expect(200);
+
+      chai.expect(body).to.be.an("object");
+      chai.expect(Object.keys(body).length).to.not.equal(0);
+    });
+
+    it("/api/v2/lumens/total-supply should return successfuly with data", async function() {
+      let { body } = await request(app)
+        .get("/api/v2/lumens/total-supply")
+        .expect(200);
+
+      chai.expect(body).to.be.an("number");
+      chai.expect(body).to.not.equal(0);
+    });
+
+    it("/api/v2/lumens/circulating-supply should return successfuly with data", async function() {
+      let { body } = await request(app)
+        .get("/api/v2/lumens/circulating-supply")
+        .expect(200);
+
+      chai.expect(body).to.be.an("number");
+      chai.expect(body).to.not.equal(0);
+    });
+
+    it("/api/v3/lumens should return successfuly with data", async function() {
+      let { body } = await request(app)
+        .get("/api/v3/lumens")
+        .expect(200);
+
+      chai.expect(body).to.be.an("object");
+      chai.expect(Object.keys(body).length).to.not.equal(0);
+    });
+
+    it("/api/v3/lumens/all should return successfuly with data", async function() {
+      let { body } = await request(app)
+        .get("/api/v3/lumens/all")
+        .expect(200);
+
+      chai.expect(body).to.be.an("object");
+      chai.expect(Object.keys(body).length).to.not.equal(0);
+    });
+
+    it("/api/v3/lumens/total-supply should return successfuly with data", async function() {
+      let { body } = await request(app)
+        .get("/api/v3/lumens/total-supply")
+        .expect(200);
+
+      chai.expect(body).to.be.an("string");
+      chai.expect(body).to.not.equal("");
+    });
+
+    it("/api/v3/lumens/circulating-supply should return successfuly with data", async function() {
+      let { body } = await request(app)
+        .get("/api/v3/lumens/circulating-supply")
+        .expect(200);
+
+      chai.expect(body).to.be.an("string");
+      chai.expect(body).to.not.equal("");
     });
   });
 });
-
-const containsData = function(data) {
-  switch (typeof data) {
-    case "object":
-      return Object.keys(data).length > 0;
-    case "array":
-      return data.length > 0;
-    case "string":
-      return data.length > 0;
-    case "number":
-      return data != 0;
-    case "undefined":
-      return false;
-    case "null":
-      return false;
-  }
-};

--- a/test/tests/integration/backend.js
+++ b/test/tests/integration/backend.js
@@ -63,8 +63,8 @@ const containsData = function(data) {
     case "number":
       return data == 0;
     case "undefined":
-      return true;
+      return false;
     case "null":
-      return true;
+      return false;
   }
 };

--- a/test/tests/integration/backend.js
+++ b/test/tests/integration/backend.js
@@ -11,45 +11,38 @@ describe("integration", function() {
     await updateResults();
   });
 
-  describe("", function() {
-    it("should return correct type", async function() {
+  describe("backend api endpoints", function() {
+    it("should return data of correct type", async function() {
       let testCases = [
         {
           url: "/api/ledgers/public",
           wantResultType: "array",
-          emptyState: {},
         },
         {
           url: "/api/lumens",
           wantResultType: "object",
-          emptyState: {},
         },
         {
           url: "/api/v2/lumens",
           wantResultType: "object",
-          emptyState: {},
         },
         {
           url: "/api/v2/lumens/total-supply",
           wantResultType: "number",
-          emptyState: "",
         },
         {
           url: "/api/v2/lumens/circulating-supply",
           wantResultType: "number",
-          emptyState: "",
         },
-        { url: "/api/v3/lumens", wantResultType: "object", emptyState: {} },
-        { url: "/api/v3/lumens/all", wantResultType: "object", emptyState: {} },
+        { url: "/api/v3/lumens", wantResultType: "object" },
+        { url: "/api/v3/lumens/all", wantResultType: "object" },
         {
           url: "/api/v3/lumens/total-supply",
           wantResultType: "string",
-          emptyState: "",
         },
         {
           url: "/api/v3/lumens/circulating-supply",
           wantResultType: "string",
-          emptyState: "",
         },
       ];
 
@@ -59,15 +52,26 @@ describe("integration", function() {
           .get(tc.url)
           .expect(200);
 
-        // ALEC TODO - remove
-        console.log(body);
-        console.log(typeof body);
-
-        console.log(body == "{}");
-
-        // chai.expect(body).to.be.an(tc.wantResultType);
-        chai.expect(body).to.not.equal(tc.emptyState);
+        chai.expect(body).to.be.an(tc.wantResultType);
+        chai.expect(containsData(body)).to.be.false;
       }
     });
   });
 });
+
+const containsData = function(data) {
+  switch (typeof data) {
+    case "object":
+      return Object.keys(data).length == 0;
+    case "array":
+      return data.length == 0;
+    case "string":
+      return data.length == 0;
+    case "number":
+      return data == 0;
+    case "undefined":
+      return true;
+    case "null":
+      return true;
+  }
+};

--- a/test/tests/integration/backend.js
+++ b/test/tests/integration/backend.js
@@ -46,7 +46,7 @@ describe("integration", function() {
           .expect(200);
 
         chai.expect(body).to.be.an(tc.wantResultType);
-        chai.expect(containsData(body)).to.be.false;
+        chai.expect(containsData(body)).to.be.true;
       }
     });
   });
@@ -55,13 +55,13 @@ describe("integration", function() {
 const containsData = function(data) {
   switch (typeof data) {
     case "object":
-      return Object.keys(data).length == 0;
+      return Object.keys(data).length > 0;
     case "array":
-      return data.length == 0;
+      return data.length > 0;
     case "string":
-      return data.length == 0;
+      return data.length > 0;
     case "number":
-      return data == 0;
+      return data != 0;
     case "undefined":
       return false;
     case "null":

--- a/test/tests/integration/backend.js
+++ b/test/tests/integration/backend.js
@@ -1,0 +1,73 @@
+import chai from "chai";
+const request = require("supertest");
+
+const { app, updateLumensCache } = require("../../../backend/app.js");
+const { updateResults, cachedData } = require("../../../backend/ledgers.js");
+
+describe("integration", function() {
+  // update caches
+  before(async function() {
+    await updateLumensCache();
+    await updateResults();
+  });
+
+  describe("", function() {
+    it("should return correct type", async function() {
+      let testCases = [
+        {
+          url: "/api/ledgers/public",
+          wantResultType: "array",
+          emptyState: {},
+        },
+        {
+          url: "/api/lumens",
+          wantResultType: "object",
+          emptyState: {},
+        },
+        {
+          url: "/api/v2/lumens",
+          wantResultType: "object",
+          emptyState: {},
+        },
+        {
+          url: "/api/v2/lumens/total-supply",
+          wantResultType: "number",
+          emptyState: "",
+        },
+        {
+          url: "/api/v2/lumens/circulating-supply",
+          wantResultType: "number",
+          emptyState: "",
+        },
+        { url: "/api/v3/lumens", wantResultType: "object", emptyState: {} },
+        { url: "/api/v3/lumens/all", wantResultType: "object", emptyState: {} },
+        {
+          url: "/api/v3/lumens/total-supply",
+          wantResultType: "string",
+          emptyState: "",
+        },
+        {
+          url: "/api/v3/lumens/circulating-supply",
+          wantResultType: "string",
+          emptyState: "",
+        },
+      ];
+
+      for (var tc of testCases) {
+        console.log("testing: ", tc.url);
+        let { body } = await request(app)
+          .get(tc.url)
+          .expect(200);
+
+        // ALEC TODO - remove
+        console.log(body);
+        console.log(typeof body);
+
+        console.log(body == "{}");
+
+        // chai.expect(body).to.be.an(tc.wantResultType);
+        chai.expect(body).to.not.equal(tc.emptyState);
+      }
+    });
+  });
+});

--- a/test/tests/unit/backend.js
+++ b/test/tests/unit/backend.js
@@ -30,7 +30,7 @@ describe("lumens v1", function() {
   });
 });
 
-describe("lumens v2", function() {
+describe("lumens v2v3", function() {
   describe("updateApiLumens", function() {
     it("should run without error and caches should update", async function() {
       let err = await v2v3.updateApiLumens();

--- a/test/tests/unit/backend.js
+++ b/test/tests/unit/backend.js
@@ -1,6 +1,6 @@
 import chai from "chai";
-const v1 = require("../../backend/lumens.js");
-const v2v3 = require("../../backend/v2v3/lumens.js");
+const v1 = require("../../../backend/lumens.js");
+const v2v3 = require("../../../backend/v2v3/lumens.js");
 
 describe("lumens v1", function() {
   describe("updateApiLumens", function() {

--- a/test/tests/unit/backend.js
+++ b/test/tests/unit/backend.js
@@ -30,7 +30,7 @@ describe("lumens v1", function() {
   });
 });
 
-describe("lumens v2v3", function() {
+describe("lumens v2", function() {
   describe("updateApiLumens", function() {
     it("should run without error and caches should update", async function() {
       let err = await v2v3.updateApiLumens();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1245,6 +1245,14 @@ cache-base@^1.0.1:
     union-value "^1.0.0"
     unset-value "^1.0.0"
 
+call-bind@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"
+  integrity sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==
+  dependencies:
+    function-bind "^1.1.1"
+    get-intrinsic "^1.0.2"
+
 caller-callsite@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/caller-callsite/-/caller-callsite-2.0.0.tgz#847e0fce0a223750a9a027c54b33731ad3154134"
@@ -1552,7 +1560,7 @@ color-support@^1.1.3:
   resolved "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2"
   integrity sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==
 
-combined-stream@^1.0.6, combined-stream@~1.0.6:
+combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -1579,7 +1587,7 @@ component-emitter@1.2.1:
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
   integrity sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=
 
-component-emitter@^1.2.1:
+component-emitter@^1.2.1, component-emitter@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
   integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
@@ -1659,6 +1667,11 @@ cookie@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
+
+cookiejar@^2.1.2:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.3.tgz#fc7a6216e408e74414b90230050842dacda75acc"
+  integrity sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ==
 
 copy-descriptor@^0.1.0:
   version "0.1.1"
@@ -2421,6 +2434,11 @@ fast-json-stable-stringify@^2.0.0:
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
   integrity sha1-1RQsDK7msRifh9OnYREGT4bIu/I=
 
+fast-safe-stringify@^2.0.7:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
+  integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
+
 fbemitter@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/fbemitter/-/fbemitter-2.1.1.tgz#523e14fdaf5248805bb02f62efc33be703f51865"
@@ -2636,6 +2654,15 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
 
+form-data@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
+  integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
 form-data@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
@@ -2644,6 +2671,11 @@ form-data@~2.3.2:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
+
+formidable@^1.2.2:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.2.6.tgz#d2a51d60162bbc9b4a055d8457a7c75315d1a168"
+  integrity sha512-KcpbcpuLNOwrEjnbpMC0gS+X8ciDoZE1kkqzat4a8vrprf+s9pKNQ/QIwWfbfs4ltgmFl3MD177SNTkve3BwGQ==
 
 forwarded@~0.1.2:
   version "0.1.2"
@@ -2706,6 +2738,11 @@ fstream@^1.0.0, fstream@^1.0.12:
     mkdirp ">=0.5 0"
     rimraf "2"
 
+function-bind@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
+  integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
+
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
@@ -2748,6 +2785,15 @@ get-func-name@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
   integrity sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=
+
+get-intrinsic@^1.0.2:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6"
+  integrity sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==
+  dependencies:
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.1"
 
 get-own-enumerable-property-symbols@^3.0.0:
   version "3.0.1"
@@ -3063,6 +3109,11 @@ has-gulplog@^0.1.0:
   dependencies:
     sparkles "^1.0.0"
 
+has-symbols@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.2.tgz#165d3070c00309752a1236a479331e3ac56f1423"
+  integrity sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==
+
 has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
@@ -3098,6 +3149,13 @@ has-values@^1.0.0:
   dependencies:
     is-number "^3.0.0"
     kind-of "^4.0.0"
+
+has@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
+  integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
+  dependencies:
+    function-bind "^1.1.1"
 
 he@1.2.0:
   version "1.2.0"
@@ -4210,6 +4268,13 @@ lru-cache@^4.0.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+  dependencies:
+    yallist "^4.0.0"
+
 make-iterator@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/make-iterator/-/make-iterator-1.0.1.tgz#29b33f312aa8f547c4a5e490f56afcec99133ad6"
@@ -4278,7 +4343,7 @@ merge-descriptors@1.0.1:
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
   integrity sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=
 
-methods@~1.1.2:
+methods@^1.1.2, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
@@ -4342,6 +4407,11 @@ mime@1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
+
+mime@^2.4.6:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.6.0.tgz#a2a682a95cd4d0cb1d6257e28f83da7e35800367"
+  integrity sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==
 
 mimic-fn@^1.0.0:
   version "1.2.0"
@@ -4787,6 +4857,11 @@ object-copy@^0.1.0:
     copy-descriptor "^0.1.0"
     define-property "^0.2.5"
     kind-of "^3.0.3"
+
+object-inspect@^1.9.0:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.11.1.tgz#d4bd7d7de54b9a75599f59a00bd698c1f1c6549b"
+  integrity sha512-If7BjFlpkzzBeV1cqgT3OSWT3azyoxDGajR+iGnFBfVV2EWyDyWaZZW2ERDjUaY2QM8i5jI3Sj7mhsM4DDAqWA==
 
 object-path@^0.9.0:
   version "0.9.2"
@@ -5452,6 +5527,13 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
+qs@^6.9.4:
+  version "6.10.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.2.tgz#c1431bea37fc5b24c5bdbafa20f16bdf2a4b9ffe"
+  integrity sha512-mSIdjzqznWgfd4pMii7sHtaYF8rx8861hBO80SraY5GT0XQibWZWJSid0avzHGkDIZLImux2S5mXO0Hfct2QCw==
+  dependencies:
+    side-channel "^1.0.4"
+
 qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
@@ -5617,6 +5699,15 @@ readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable
     safe-buffer "~5.1.1"
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
+
+readable-stream@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
+  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
 
 readable-stream@~1.1.9:
   version "1.1.14"
@@ -5888,6 +5979,11 @@ safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.2:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
   integrity sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==
 
+safe-buffer@~5.2.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
 safe-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/safe-regex/-/safe-regex-1.1.0.tgz#40a3669f3b077d1e943d44629e157dd48023bf2e"
@@ -5982,6 +6078,13 @@ semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.3.2:
+  version "7.3.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
+  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+  dependencies:
+    lru-cache "^6.0.0"
 
 semver@~5.3.0:
   version "5.3.0"
@@ -6170,6 +6273,15 @@ shimmer@^1.1.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/shimmer/-/shimmer-1.2.1.tgz#610859f7de327b587efebf501fb43117f9aff337"
   integrity sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==
+
+side-channel@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
+  integrity sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==
+  dependencies:
+    call-bind "^1.0.0"
+    get-intrinsic "^1.0.2"
+    object-inspect "^1.9.0"
 
 sigmund@~1.0.0:
   version "1.0.1"
@@ -6567,6 +6679,13 @@ string_decoder@^0.10.25, string_decoder@~0.10.x:
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
   integrity sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=
 
+string_decoder@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
+
 string_decoder@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
@@ -6662,6 +6781,31 @@ style-to-object@0.3.0:
   integrity sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==
   dependencies:
     inline-style-parser "0.1.1"
+
+superagent@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/superagent/-/superagent-6.1.0.tgz#09f08807bc41108ef164cfb4be293cebd480f4a6"
+  integrity sha512-OUDHEssirmplo3F+1HWKUrUjvnQuA+nZI6i/JJBdXb5eq9IyEQwPyPpqND+SSsxf6TygpBEkUjISVRN4/VOpeg==
+  dependencies:
+    component-emitter "^1.3.0"
+    cookiejar "^2.1.2"
+    debug "^4.1.1"
+    fast-safe-stringify "^2.0.7"
+    form-data "^3.0.0"
+    formidable "^1.2.2"
+    methods "^1.1.2"
+    mime "^2.4.6"
+    qs "^6.9.4"
+    readable-stream "^3.6.0"
+    semver "^7.3.2"
+
+supertest@^6.1.6:
+  version "6.1.6"
+  resolved "https://registry.yarnpkg.com/supertest/-/supertest-6.1.6.tgz#6151c518f4c5ced2ac2aadb9f96f1bf8198174c8"
+  integrity sha512-0hACYGNJ8OHRg8CRITeZOdbjur7NLuNs0mBjVhdpxi7hP6t3QIbOzLON5RTUmZcy2I9riuII3+Pr2C7yztrIIg==
+  dependencies:
+    methods "^1.1.2"
+    superagent "^6.1.0"
 
 supports-color@8.1.1:
   version "8.1.1"
@@ -7036,7 +7180,7 @@ user-home@^1.1.1:
   resolved "https://registry.yarnpkg.com/user-home/-/user-home-1.1.1.tgz#2b5be23a32b63a7c9deb8d0f28d485724a3df190"
   integrity sha1-K1viOjK2Onyd640PKNSFcko98ZA=
 
-util-deprecate@~1.0.1:
+util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
@@ -7318,6 +7462,11 @@ yallist@^3.0.0, yallist@^3.0.3:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yargs-parser@20.2.4:
   version "20.2.4"


### PR DESCRIPTION
**WHAT**
add integration tests for the backend api endpoints

**WHY**
to ensure they work as intended during code changes. Will help with project maintenance going forward.

note: the only endpoint not currently tested is `api/ledgers/public`, because it requires a postgres database. I followed [directions here](https://docs.github.com/en/actions/using-containerized-services/creating-postgresql-service-containers) but couldn't get it working correctly (though it is pretty cool), and the plan is to deprecate postgres for redis anyways so ignoring that endpoint until then