### PR TITLE
backend: only update redis from one pod

### DIFF
--- a/backend/app.ts
+++ b/backend/app.ts
@@ -8,11 +8,11 @@ const { updateLumensCache } = require("./routes");
 const { updateLedgers } = require("./ledgers");
 
 (async () => {
-  setInterval(updateLumensCache, 10 * 60 * 1000);
-  console.log("starting lumens cache update");
-  await updateLumensCache();
-
   if (process.env.UPDATE_DATA == "true") {
+    setInterval(updateLumensCache, 10 * 60 * 1000);
+    console.log("starting lumens cache update");
+    await updateLumensCache();
+
     console.log("starting ledgers cache update");
     await updateLedgers();
   }


### PR DESCRIPTION
**WHAT**
only update the lumens cache in redis if `process.env.UPDATE_DATA == "true"` 

**WHY**
before adding redis the pods were updating data in memory, so every pod needed to run the `updateLumensCache` function. But since the project is using redis now, only one pod the "updater" pod needs to run this code, as more than one running it is excessive. Cuts the calls to Horizon from this project in half  ( ^o^)ノ＼(^_^ )