### PR TITLE
SDFD-19 Feat: Add missing charts for existing sections

### DIFF
--- a/frontend/src/components/LastLedger/index.tsx
+++ b/frontend/src/components/LastLedger/index.tsx
@@ -1,8 +1,11 @@
 import { Icon } from "@stellar/design-system";
+
 import { networkConfig } from "constants/settings";
 import { useRedux } from "hooks/useRedux";
 import { SectionCard } from "components/SectionCard";
 import { LedgerClosedTime } from "components/LedgerClosedTime";
+import { CircularChart } from "components/charts/CircularChart";
+import { BatteryLikeChart } from "components/charts/BatteryLikeChart";
 import { ActionStatus, Network } from "types";
 
 import "./styles.scss";
@@ -33,17 +36,34 @@ export const LastLedger = ({
             <div className="LastLedger__row">
               <div className="LastLedger__row__label">Transactions</div>
               <div className="LastLedger__row__value">
-                {/* TODO: add chart */}
+                <div className="LastLedger__row__value__circular_chart">
+                  <CircularChart
+                    data={[
+                      {
+                        label: "Succeeded",
+                        value: lastLedger.txCountSuccessful,
+                      },
+                      { label: "Failed", value: lastLedger.txCountFailed },
+                    ]}
+                    lineWidth={0.5}
+                    tooltipEnabled={false}
+                    colorType={CircularChart.ColorType.SECONDARY}
+                  />
+                </div>
                 {lastLedger.txCountSuccessful} succeeded <span>/</span>{" "}
                 {lastLedger.txCountFailed} failed
               </div>
             </div>
             <div className="LastLedger__row">
               <div className="LastLedger__row__label">Operations</div>
-              <div className="LastLedger__row__value">{lastLedger.opCount}</div>
+              <div className="LastLedger__row__value">
+                <div className="LastLedger__row__value__battery_chart">
+                  <BatteryLikeChart value={lastLedger.opCount / 10} />
+                </div>
+                {lastLedger.opCount}
+              </div>
             </div>
             <div className="LastLedger__row">
-              {/* TODO: add chart */}
               <div className="LastLedger__row__label">Ledger closing time</div>
               <div className="LastLedger__row__value">
                 <LedgerClosedTime closedTime={lastLedger.closedTime} />

--- a/frontend/src/components/LastLedger/styles.scss
+++ b/frontend/src/components/LastLedger/styles.scss
@@ -44,6 +44,18 @@
       align-items: center;
       gap: 0.3rem;
 
+      &__circular_chart {
+        width: 1rem;
+        height: 1rem;
+        margin-right: 0.2rem;
+      }
+
+      &__battery_chart {
+        width: 0.75rem;
+        height: 1rem;
+        margin-right: 0.2rem;
+      }
+
       span {
         color: var(--pal-text-tertiary);
       }

--- a/frontend/src/components/LastLedgersInfo/index.tsx
+++ b/frontend/src/components/LastLedgersInfo/index.tsx
@@ -1,9 +1,12 @@
 import React from "react";
 import { Table, Icon } from "@stellar/design-system";
+
 import { networkConfig } from "constants/settings";
 import { useRedux } from "hooks/useRedux";
 import { SectionCard } from "components/SectionCard";
 import { LedgerClosedTime } from "components/LedgerClosedTime";
+import { CircularChart } from "components/charts/CircularChart";
+import { BatteryLikeChart } from "components/charts/BatteryLikeChart";
 import { LedgerItem, Network } from "types";
 
 import "./styles.scss";
@@ -44,15 +47,28 @@ export const LastLedgersInfo = ({
       <td className="LastLedgersInfo__sequence">{ledger.sequenceNumber}</td>
       <td>
         <div className="LastLedgersInfo__chartWrapper">
-          {/* TODO: add chart */}
-          <div className="LastLedgersInfo__pieChart" />
+          <div className="LastLedgersInfo__pieChart">
+            <CircularChart
+              data={[
+                {
+                  label: "Succeeded",
+                  value: ledger.txCountSuccessful,
+                },
+                { label: "Failed", value: ledger.txCountFailed },
+              ]}
+              lineWidth={0.5}
+              tooltipEnabled={false}
+              colorType={CircularChart.ColorType.SECONDARY}
+            />
+          </div>
           {ledger.txCountSuccessful} succeeded / {ledger.txCountFailed} failed
         </div>
       </td>
-      {/* TODO: add chart */}
       <td>
         <div className="LastLedgersInfo__chartWrapper">
-          <div className="LastLedgersInfo__barChart" />
+          <div className="LastLedgersInfo__barChart">
+            <BatteryLikeChart value={ledger.opCount / 10} />
+          </div>
           {ledger.opCount}
         </div>
       </td>

--- a/frontend/src/components/LastLedgersInfo/styles.scss
+++ b/frontend/src/components/LastLedgersInfo/styles.scss
@@ -38,13 +38,10 @@
   &__pieChart {
     width: 1rem;
     height: 1rem;
-    border-radius: 0.5rem;
-    background-color: var(--pal-border-primary);
   }
 
   &__barChart {
     width: 0.75rem;
     height: 1rem;
-    background-color: var(--pal-border-primary);
   }
 }

--- a/frontend/src/components/LumenSupply/index.tsx
+++ b/frontend/src/components/LumenSupply/index.tsx
@@ -4,6 +4,10 @@ import { useDispatch } from "react-redux";
 import BigNumber from "bignumber.js";
 
 import { SectionCard } from "components/SectionCard";
+import {
+  CircularChart,
+  CircularChartData,
+} from "components/charts/CircularChart";
 import { DASHBOARD_URL, FRIENDBOT_PUBLIC_ADDRESS } from "constants/settings";
 import { fetchLumenSupplyAction } from "ducks/lumenSupply";
 import { formatAmount } from "helpers/formatAmount";
@@ -44,18 +48,48 @@ export const LumenSupply = ({
       ),
       amount: data?.circulating,
       apiUrl: isTestnet ? null : apiEndpoint,
+      chartData: [
+        {
+          label: "Circulating",
+          value: new BigNumber(data?.circulating ?? 1).toNumber(),
+        },
+        {
+          label: "Placeholder",
+          value: 0,
+        },
+      ] as CircularChartData,
     },
     {
       id: "nonCirculating",
       label: "Non-Circulating Supply",
       amount: data?.nonCirculating,
       apiUrl: isTestnet ? null : apiEndpoint,
+      chartData: [
+        {
+          label: "Placeholder",
+          value: 0,
+        },
+        {
+          label: "Non-Circulating",
+          value: new BigNumber(data?.nonCirculating ?? 1).toNumber(),
+        },
+      ] as CircularChartData,
     },
     {
       id: "total",
       label: "Total XLM Supply",
       amount: data?.total,
       apiUrl: isTestnet ? null : apiEndpoint,
+      chartData: [
+        {
+          label: `${formatAmount(data?.circulating ?? 1)} XLM`,
+          value: new BigNumber(data?.circulating ?? 1).toNumber(),
+        },
+        {
+          label: `${formatAmount(data?.nonCirculating ?? 1)} XLM`,
+          value: new BigNumber(data?.nonCirculating ?? 1).toNumber(),
+        },
+      ] as CircularChartData,
     },
   ];
 
@@ -70,7 +104,21 @@ export const LumenSupply = ({
       {data ? (
         <div className="LumenSupply">
           <div className="LumenSupply__chart">
-            <div className="LumenSupply__chart__item" />
+            <div className="LumenSupply__chart__item">
+              <CircularChart
+                data={[
+                  {
+                    label: `${formatAmount(data.circulating)} XLM`,
+                    value: new BigNumber(data.circulating).toNumber(),
+                  },
+                  {
+                    label: `${formatAmount(data.nonCirculating)} XLM`,
+                    value: new BigNumber(data.nonCirculating).toNumber(),
+                  },
+                ]}
+                tooltipTitle="Total XLM"
+              />
+            </div>
           </div>
           <div className="LumenSupply__supply">
             {items.map((i) => (
@@ -85,7 +133,13 @@ export const LumenSupply = ({
                       }
                     `}
                   >
-                    <div className="LumenSupply__supply__item__chart" />
+                    <div className="LumenSupply__supply__item__chart">
+                      <CircularChart
+                        data={i.chartData}
+                        tooltipEnabled={false}
+                        lineWidth={1}
+                      />
+                    </div>
                     {i.label}
                   </div>
                   {i.apiUrl ? (

--- a/frontend/src/components/LumenSupply/index.tsx
+++ b/frontend/src/components/LumenSupply/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { TextLink, Icon } from "@stellar/design-system";
 import { useDispatch } from "react-redux";
 import BigNumber from "bignumber.js";
@@ -16,6 +16,8 @@ import { ActionStatus, Network } from "types";
 
 import "./styles.scss";
 
+const apiEndpoint = `${DASHBOARD_URL}/api/v3/lumens/`;
+
 export const LumenSupply = ({
   network = Network.MAINNET,
 }: {
@@ -24,74 +26,79 @@ export const LumenSupply = ({
   const { lumenSupply } = useRedux("lumenSupply");
   const { data } = lumenSupply;
   const dispatch = useDispatch();
-  const isTestnet = network === Network.TESTNET;
-  const apiEndpoint = `${DASHBOARD_URL}/api/v3/lumens/`;
+  const isTestnet = useMemo(() => network === Network.TESTNET, [network]);
 
   useEffect(() => {
     dispatch(fetchLumenSupplyAction(network));
   }, [network, dispatch]);
 
-  const items = [
-    {
-      id: "circulating",
-      label: isTestnet ? (
-        <>
-          Friendbot:
-          <TextLink
-            href={`https://horizon-testnet.stellar.org/accounts/${FRIENDBOT_PUBLIC_ADDRESS}`}
-          >
-            GAIH
-          </TextLink>
-        </>
-      ) : (
-        "Circulating Supply"
-      ),
-      amount: data?.circulating,
-      apiUrl: isTestnet ? null : apiEndpoint,
-      chartData: [
-        {
-          label: "Circulating",
-          value: new BigNumber(data?.circulating ?? 1).toNumber(),
-        },
-        {
-          label: "Placeholder",
-          value: 0,
-        },
-      ] as CircularChartData,
-    },
-    {
-      id: "nonCirculating",
-      label: "Non-Circulating Supply",
-      amount: data?.nonCirculating,
-      apiUrl: isTestnet ? null : apiEndpoint,
-      chartData: [
-        {
-          label: "Placeholder",
-          value: 0,
-        },
-        {
-          label: "Non-Circulating",
-          value: new BigNumber(data?.nonCirculating ?? 1).toNumber(),
-        },
-      ] as CircularChartData,
-    },
-    {
-      id: "total",
-      label: "Total XLM Supply",
-      amount: data?.total,
-      apiUrl: isTestnet ? null : apiEndpoint,
-      chartData: [
-        {
-          label: `${formatAmount(data?.circulating ?? 1)} XLM`,
-          value: new BigNumber(data?.circulating ?? 1).toNumber(),
-        },
-        {
-          label: `${formatAmount(data?.nonCirculating ?? 1)} XLM`,
-          value: new BigNumber(data?.nonCirculating ?? 1).toNumber(),
-        },
-      ] as CircularChartData,
-    },
-  ];
+  const items = useMemo(() => {
+    if (!data) {
+      return [];
+    }
+
+    return [
+      {
+        id: "circulating",
+        label: isTestnet ? (
+          <>
+            Friendbot:
+            <TextLink
+              href={`https://horizon-testnet.stellar.org/accounts/${FRIENDBOT_PUBLIC_ADDRESS}`}
+            >
+              GAIH
+            </TextLink>
+          </>
+        ) : (
+          "Circulating Supply"
+        ),
+        amount: data.circulating,
+        apiUrl: isTestnet ? null : apiEndpoint,
+        chartData: [
+          {
+            label: "Circulating",
+            value: new BigNumber(data.circulating).toNumber(),
+          },
+          {
+            label: "Placeholder",
+            value: 0,
+          },
+        ] as CircularChartData,
+      },
+      {
+        id: "nonCirculating",
+        label: "Non-Circulating Supply",
+        amount: data.nonCirculating,
+        apiUrl: isTestnet ? null : apiEndpoint,
+        chartData: [
+          {
+            label: "Placeholder",
+            value: 0,
+          },
+          {
+            label: "Non-Circulating",
+            value: new BigNumber(data.nonCirculating).toNumber(),
+          },
+        ] as CircularChartData,
+      },
+      {
+        id: "total",
+        label: "Total XLM Supply",
+        amount: data.total,
+        apiUrl: isTestnet ? null : apiEndpoint,
+        chartData: [
+          {
+            label: `${formatAmount(data.circulating)} XLM`,
+            value: new BigNumber(data.circulating).toNumber(),
+          },
+          {
+            label: `${formatAmount(data.nonCirculating)} XLM`,
+            value: new BigNumber(data.nonCirculating).toNumber(),
+          },
+        ] as CircularChartData,
+      },
+    ];
+  }, [data, isTestnet]);
 
   return (
     <SectionCard

--- a/frontend/src/components/LumenSupply/styles.scss
+++ b/frontend/src/components/LumenSupply/styles.scss
@@ -8,6 +8,8 @@
     display: flex;
     justify-content: center;
     width: 100%;
+    // because of the tooltip, we need to add this z-index here
+    z-index: 1;
 
     @media (min-width: 540px) {
       width: 11.75rem;
@@ -16,8 +18,6 @@
     &__item {
       width: 7.5rem;
       height: 7.5rem;
-      border-radius: 3.75rem;
-      background-color: var(--pal-border-primary);
     }
   }
 
@@ -65,15 +65,17 @@
         color: var(--pal-text-tertiary);
         display: flex;
         align-items: center;
-        gap: 0.2rem;
+        gap: 0.5rem;
       }
 
       &__chart {
         width: 0.5rem;
         height: 0.5rem;
-        border-radius: 0.25rem;
-        background-color: var(--pal-border-primary);
-        margin-right: 0.3rem;
+
+        // because of the small size, we need to do the following to make the chart be aligned correctly
+        .CircularChart {
+          display: flex;
+        }
       }
 
       &__bold {

--- a/frontend/src/components/NetworkNodes/index.tsx
+++ b/frontend/src/components/NetworkNodes/index.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { useDispatch } from "react-redux";
 
 import { SectionCard } from "components/SectionCard";
+import { AreaChart } from "components/charts/AreaChart";
 import { fetchNetworkNodesAction } from "ducks/networkNodes";
 import { useRedux } from "hooks/useRedux";
 import { ActionStatus, Network, NetworkNodesType } from "types";
@@ -68,9 +69,12 @@ export const NetworkNodes = ({
           ? nodes.map((n) => (
               <div className="NetworkNodes__node" key={n.id}>
                 <div className="NetworkNodes__node__label">{n.label}</div>
-                {/* TODO: add chart */}
-                <div className="NetworkNodes__node__chart"></div>
-                <div className="NetworkNodes__node__count">{data[n.id]}</div>
+                <div className="NetworkNodes__node__chart">
+                  <AreaChart data={data[n.id].historyStats} />
+                </div>
+                <div className="NetworkNodes__node__count">
+                  {data[n.id].current}
+                </div>
               </div>
             ))
           : null}

--- a/frontend/src/components/NetworkNodes/styles.scss
+++ b/frontend/src/components/NetworkNodes/styles.scss
@@ -39,7 +39,6 @@
       flex-shrink: 0;
       width: 4.5rem;
       height: 1.6rem;
-      border: 1px solid var(--pal-border-primary);
     }
 
     &__count {

--- a/frontend/src/helpers/getNetworkNodesHistoryData.ts
+++ b/frontend/src/helpers/getNetworkNodesHistoryData.ts
@@ -1,0 +1,105 @@
+import { NetworkNodeItemData, NetworkNodesType } from "types";
+
+type StatisticsResponseItem = {
+  time: Date;
+  nrOfActiveWatchersSum: number;
+  nrOfActiveValidatorsSum: number;
+  nrOfActiveFullValidatorsSum: number;
+  nrOfActiveOrganizationsSum: number;
+  transitiveQuorumSetSizeSum: number;
+  hasQuorumIntersectionCount: number;
+  hasTransitiveQuorumSetCount: number;
+  hasSymmetricTopTierCount: number;
+  topTierMin: number;
+  topTierMax: number;
+  topTierSum: number;
+  topTierOrgsMin: number;
+  topTierOrgsMax: number;
+  topTierOrgsSum: number;
+  minBlockingSetMin: number;
+  minBlockingSetMax: number;
+  minBlockingSetSum: number;
+  minBlockingSetOrgsMin: number;
+  minBlockingSetOrgsMax: number;
+  minBlockingSetOrgsSum: number;
+  minBlockingSetFilteredMin: number;
+  minBlockingSetFilteredMax: number;
+  minBlockingSetFilteredSum: number;
+  minBlockingSetOrgsFilteredMin: number;
+  minBlockingSetOrgsFilteredMax: number;
+  minBlockingSetOrgsFilteredSum: number;
+  minSplittingSetMin: number;
+  minSplittingSetMax: number;
+  minSplittingSetSum: number;
+  minSplittingSetOrgsMin: number;
+  minSplittingSetOrgsMax: number;
+  minSplittingSetOrgsSum: number;
+  minBlockingSetCountryMin: number;
+  minBlockingSetCountryMax: number;
+  minBlockingSetCountrySum: number;
+  minBlockingSetCountryFilteredMin: number;
+  minBlockingSetCountryFilteredMax: number;
+  minBlockingSetCountryFilteredSum: number;
+  minBlockingSetISPMin: number;
+  minBlockingSetISPMax: number;
+  minBlockingSetISPSum: number;
+  minBlockingSetISPFilteredMin: number;
+  minBlockingSetISPFilteredMax: number;
+  minBlockingSetISPFilteredSum: number;
+  minSplittingSetCountryMin: number;
+  minSplittingSetCountryMax: number;
+  minSplittingSetCountrySum: number;
+  minSplittingSetISPMin: number;
+  minSplittingSetISPMax: number;
+  minSplittingSetISPSum: number;
+  crawlCount: number;
+};
+
+type NormalizedStatistics = Record<
+  NetworkNodesType,
+  NetworkNodeItemData["historyStats"]
+>;
+
+export const getNetworkNodesHistoryData = (
+  graphStatistics: StatisticsResponseItem[],
+) => {
+  return graphStatistics.reduce(
+    (acc: NormalizedStatistics, item) => {
+      const name = item.time.toString();
+      acc[NetworkNodesType.WATCHER_NODES].push({
+        name,
+        value: item.nrOfActiveWatchersSum,
+      });
+      acc[NetworkNodesType.VALIDATOR_NODES].push({
+        name,
+        value: item.nrOfActiveValidatorsSum,
+      });
+      acc[NetworkNodesType.FULL_VALIDATORS].push({
+        name,
+        value: item.nrOfActiveFullValidatorsSum,
+      });
+      acc[NetworkNodesType.ORGANIZATIONS].push({
+        name,
+        value: item.nrOfActiveOrganizationsSum,
+      });
+      acc[NetworkNodesType.TOP_TIER_VALIDATORS].push({
+        name,
+        value: item.topTierSum,
+      });
+      acc[NetworkNodesType.TOP_TIER_ORGANIZATIONS].push({
+        name,
+        value: item.topTierOrgsSum,
+      });
+
+      return acc;
+    },
+    {
+      [NetworkNodesType.WATCHER_NODES]: [],
+      [NetworkNodesType.VALIDATOR_NODES]: [],
+      [NetworkNodesType.FULL_VALIDATORS]: [],
+      [NetworkNodesType.ORGANIZATIONS]: [],
+      [NetworkNodesType.TOP_TIER_VALIDATORS]: [],
+      [NetworkNodesType.TOP_TIER_ORGANIZATIONS]: [],
+    } as NormalizedStatistics,
+  );
+};

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -43,13 +43,21 @@ export enum NetworkNodesType {
   TOP_TIER_ORGANIZATIONS = "topTierOrganizations",
 }
 
+export interface NetworkNodeItemData {
+  current: number;
+  historyStats: {
+    name: string;
+    value: number;
+  }[];
+}
+
 export interface NetworkNodesData {
-  [NetworkNodesType.WATCHER_NODES]: number;
-  [NetworkNodesType.VALIDATOR_NODES]: number;
-  [NetworkNodesType.FULL_VALIDATORS]: number;
-  [NetworkNodesType.ORGANIZATIONS]: number;
-  [NetworkNodesType.TOP_TIER_VALIDATORS]: number;
-  [NetworkNodesType.TOP_TIER_ORGANIZATIONS]: number;
+  [NetworkNodesType.WATCHER_NODES]: NetworkNodeItemData;
+  [NetworkNodesType.VALIDATOR_NODES]: NetworkNodeItemData;
+  [NetworkNodesType.FULL_VALIDATORS]: NetworkNodeItemData;
+  [NetworkNodesType.ORGANIZATIONS]: NetworkNodeItemData;
+  [NetworkNodesType.TOP_TIER_VALIDATORS]: NetworkNodeItemData;
+  [NetworkNodesType.TOP_TIER_ORGANIZATIONS]: NetworkNodeItemData;
 }
 
 export interface LumenSupplyData {


### PR DESCRIPTION
## About

Add missing charts for existing sections of Dashboard:
- Last Ledger
- Last 10 Ledgers info
- Total XLM Issued
- Network nodes

Closes #252 

## Screenshots

<details>
<summary>Some screenshots for illustration:</summary>

All these charts are also working on Dark mode and for Testnet (if applicable). Available on PR preview.

![Screen Shot 2022-05-12 at 17 30 50](https://user-images.githubusercontent.com/17295921/168163478-3d71bb21-2bc6-431a-8144-a3cdec240405.png)
![Screen Shot 2022-05-12 at 17 31 01](https://user-images.githubusercontent.com/17295921/168163509-d7de976f-ba25-4b1a-91e1-5079dec92f02.png)
![Screen Shot 2022-05-12 at 17 31 38](https://user-images.githubusercontent.com/17295921/168163534-099b8835-8e54-4d58-8b94-6be584ba7c39.png)
![Screen Shot 2022-05-12 at 17 31 11](https://user-images.githubusercontent.com/17295921/168163563-e6ca0e37-bccb-4b13-a711-9abefa2c4f83.png)

</details>