### PR TITLE
SDFD-13_serve_1h_24h_ledger_data

### DIFF
--- a/backend/__tests__/lumens.test.ts
+++ b/backend/__tests__/lumens.test.ts
@@ -200,11 +200,13 @@ describe("ledgers", () => {
           date: "01-12",
           transaction_count: 80,
           operation_count: 300,
+          sequence: 10003,
         },
         {
           date: "01-11",
           transaction_count: 15,
           operation_count: 50,
+          sequence: 10001,
         },
       ]);
       expect(cachedPagingToken).toEqual("103");
@@ -236,7 +238,12 @@ describe("ledgers", () => {
       );
 
       expect(JSON.parse(cachedLedgers as string)).toEqual([
-        { date: "01-12", transaction_count: 403018, operation_count: 781390 },
+        {
+          date: "01-12",
+          transaction_count: 403018,
+          operation_count: 781390,
+          sequence: 39149884,
+        },
       ]);
       expect(cachedPagingToken).toEqual("168147471422193664");
     });

--- a/backend/__tests__/lumens.test.ts
+++ b/backend/__tests__/lumens.test.ts
@@ -1,5 +1,5 @@
 import { redisClient } from "../src/redisSetup";
-import { updateCache, catchup, LedgerRecord } from "../src/ledgers";
+import { updateCache, catchup, LedgerRecord, INTERVALS } from "../src/ledgers";
 import { updateApiLumens as updateApiLumensV1 } from "../src/lumens";
 import { updateApiLumens as updateApiLumensV2V3 } from "../src/v2v3/lumens";
 
@@ -188,6 +188,7 @@ describe("ledgers", () => {
         ledgers,
         REDIS_LEDGER_KEY_TEST,
         REDIS_PAGING_TOKEN_KEY_TEST,
+        INTERVALS.month,
       );
 
       const cachedLedgers = await redisClient.get(REDIS_LEDGER_KEY_TEST);
@@ -230,6 +231,7 @@ describe("ledgers", () => {
         "168143176454897664",
         REDIS_PAGING_TOKEN_KEY_TEST,
         1000,
+        INTERVALS.month,
       );
 
       const cachedLedgers = await redisClient.get(REDIS_LEDGER_KEY_TEST);
@@ -257,6 +259,7 @@ describe("ledgers", () => {
         "now",
         REDIS_PAGING_TOKEN_KEY_TEST,
         0,
+        INTERVALS.month,
       );
 
       const cachedLedgers = await redisClient.get(REDIS_LEDGER_KEY_TEST);
@@ -302,6 +305,7 @@ describe("ledgers", () => {
         ledgers,
         REDIS_LEDGER_KEY_TEST,
         REDIS_PAGING_TOKEN_KEY_TEST,
+        INTERVALS.month,
       );
 
       const cachedLedgers = await redisClient.get(REDIS_LEDGER_KEY_TEST);

--- a/backend/__tests__/lumens.test.ts
+++ b/backend/__tests__/lumens.test.ts
@@ -198,13 +198,13 @@ describe("ledgers", () => {
 
       expect(JSON.parse(cachedLedgers as string)).toEqual([
         {
-          date: "01-12",
+          date: "2022-1-12 00:00:00",
           transaction_count: 80,
           operation_count: 300,
           sequence: 10003,
         },
         {
-          date: "01-11",
+          date: "2022-1-11 00:00:00",
           transaction_count: 15,
           operation_count: 50,
           sequence: 10001,
@@ -241,7 +241,7 @@ describe("ledgers", () => {
 
       expect(JSON.parse(cachedLedgers as string)).toEqual([
         {
-          date: "01-12",
+          date: "2022-1-12 00:00:00",
           transaction_count: 403018,
           operation_count: 781390,
           sequence: 39149884,
@@ -314,7 +314,9 @@ describe("ledgers", () => {
       );
 
       expect(JSON.parse(cachedLedgers as string).length).toEqual(30);
-      expect(JSON.parse(cachedLedgers as string)[0].date).toEqual("01-31");
+      expect(JSON.parse(cachedLedgers as string)[0].date).toEqual(
+        "2022-1-31 00:00:00",
+      );
       expect(cachedPagingToken as string).toEqual("163");
     });
   });

--- a/backend/src/bigQuery.ts
+++ b/backend/src/bigQuery.ts
@@ -19,7 +19,6 @@ export const bqClient = new BigQuery(options);
 const BQHistoryLedgersTable = "crypto-stellar.crypto_stellar_2.history_ledgers";
 
 export function getBqQueryByDate(date: string) {
-  console.log("DEBUG - QUERY DATES - DATE NOW: ", new Date());
   return `SELECT id FROM \`${BQHistoryLedgersTable}\` WHERE closed_at >= "${date}" ORDER BY sequence LIMIT 1;`;
 }
 

--- a/backend/src/bigQuery.ts
+++ b/backend/src/bigQuery.ts
@@ -18,13 +18,9 @@ export const bqClient = new BigQuery(options);
 // TODO - drop the _2 when Hubble 2.0 is live
 const BQHistoryLedgersTable = "crypto-stellar.crypto_stellar_2.history_ledgers";
 
-export function get30DayOldLedgerQuery() {
-  const today = new Date();
-  const before = new Date(today.setDate(today.getDate() - 32));
-  const bqDate = `${before.getFullYear()}-${
-    before.getUTCMonth() + 1
-  }-${before.getUTCDate()}`;
-  return `SELECT * FROM \`${BQHistoryLedgersTable}\` WHERE closed_at >= "${bqDate}" ORDER BY sequence LIMIT 1;`;
+export function getBqQueryByDate(date: string) {
+  console.log("DEBUG - QUERY DATES - DATE NOW: ", new Date());
+  return `SELECT id FROM \`${BQHistoryLedgersTable}\` WHERE closed_at >= "${date}" ORDER BY sequence LIMIT 1;`;
 }
 
 export interface BQHistoryLedger {

--- a/backend/src/ledgers.ts
+++ b/backend/src/ledgers.ts
@@ -64,6 +64,7 @@ interface LedgerStat {
   date: string;
   transaction_count: number;
   operation_count: number;
+  sequence: number;
 }
 
 // TODO - import Horizon type once https://github.com/stellar/js-stellar-sdk/issues/731 resolved
@@ -214,6 +215,7 @@ export async function updateCache(
     if (index === -1) {
       cachedStats.push({
         date,
+        sequence: ledger.sequence,
         transaction_count:
           ledger.successful_transaction_count + ledger.failed_transaction_count,
         operation_count: ledger.operation_count,
@@ -221,6 +223,7 @@ export async function updateCache(
     } else {
       cachedStats.splice(index, 1, {
         date,
+        sequence: ledger.sequence,
         transaction_count:
           cachedStats[index].transaction_count +
           ledger.successful_transaction_count +

--- a/backend/src/ledgers.ts
+++ b/backend/src/ledgers.ts
@@ -211,7 +211,7 @@ export async function updateCache(
   let pagingToken = "";
 
   ledgers.forEach((ledger: LedgerRecord) => {
-    const date: string = getLedgerKey[interval](ledger.closed_at);
+    const date: string = getLedgerKey[interval](new Date(ledger.closed_at));
     const index: number = findIndex(cachedStats, { date });
     if (index === -1) {
       cachedStats.push({
@@ -260,20 +260,17 @@ function dateSorter(a: LedgerStat, b: LedgerStat) {
   return dateB.getTime() - dateA.getTime();
 }
 
-// MM-DD
-function formatDate(s: string): string {
-  const d = new Date(s);
-  const month = `0${d.getUTCMonth() + 1}`;
-  const day = `0${d.getUTCDate()}`;
-  return `${month.slice(-2)}-${day.slice(-2)}`;
-}
-
 const getLedgerKey = {
-  hour: (closed_at: string) =>
-    `${formatDate(closed_at)} ${new Date(closed_at).getUTCHours()}H:${new Date(
-      closed_at,
-    ).getUTCMinutes()}M`,
-  day: (closed_at: string) =>
-    `${formatDate(closed_at)} ${new Date(closed_at).getUTCHours()}H`,
-  month: (closed_at: string) => `${formatDate(closed_at)}`,
+  hour: (closed_at: Date) =>
+    `${closed_at.getUTCFullYear()}-${
+      closed_at.getUTCMonth() + 1
+    }-${closed_at.getUTCDate()} ${closed_at.getUTCHours()}:${closed_at.getUTCMinutes()}:00`,
+  day: (closed_at: Date) =>
+    `${closed_at.getUTCFullYear()}-${
+      closed_at.getUTCMonth() + 1
+    }-${closed_at.getUTCDate()} ${closed_at.getUTCHours()}:00:00`,
+  month: (closed_at: Date) =>
+    `${closed_at.getUTCFullYear()}-${
+      closed_at.getUTCMonth() + 1
+    }-${closed_at.getUTCDate()} 00:00:00`,
 };

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -30,7 +30,7 @@ if (process.env.DEV) {
 
 app.get("/api/ledgers/hour/public", ledgers.handler_hour);
 app.get("/api/ledgers/day/public", ledgers.handler_day);
-app.get("/api/ledgers/public", ledgers.handler);
+app.get("/api/ledgers/month/public", ledgers.handler_month);
 app.get("/api/lumens", lumens.v1Handler);
 
 app.get("/api/dex/24h-payments", dex.get24hPaymentsData);

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -28,6 +28,8 @@ if (process.env.DEV) {
   app.use(express.static("../frontend/build"));
 }
 
+app.get("/api/ledgers/hour/public", ledgers.handler_hour);
+app.get("/api/ledgers/day/public", ledgers.handler_day);
 app.get("/api/ledgers/public", ledgers.handler);
 app.get("/api/lumens", lumens.v1Handler);
 


### PR DESCRIPTION
Hey, this was a bit tricky. I tried various forms to implement this without disturbing much of the original code, this PR is the best attempt i've made with minimal changes to the original algorithm. Let me know if any of it is not ideal or otherwise inappropriate @acharb 
Some of the important changes:
- Changed the query to define our initial pointer from `select * ...` to `select id ...`, since we're only using ID and this was having a large impact on free account queries threshold. Sizes before/after:
![image](https://user-images.githubusercontent.com/8282304/172604497-83ffcaac-a56b-4556-a2be-42c8ab21291d.png)
![image](https://user-images.githubusercontent.com/8282304/172604510-157219b1-9eb3-4d9b-b301-c0fa6d8e7d4d.png)
- For the intervals, i created a data structure with values of `hour`, `day`, `month`. Various parts of the code needs different kinds of data depending on the interval we need, but if we're able to access all of them with the same key, an enum allows us to very easily make the code dynamic without much repetition or reestructuring of the original logic. Let me know if any part seems difficult to understand or counterintuitive.
- I removed the ledger fetch loop from `while(true)` to a recursive iteration, because a `while(true)` loop blocks the [event loop](https://nodejs.dev/learn/the-nodejs-event-loop), causing resources to hang until the operation completes. Creating a new scope allows the node engine to manage resources more easily. Side effects of a blocked event loop on the backend would be dynamic requests that don't answer until we finish a `catchup()` call.
- Maintained all original calls to 30 day ledger as is, all signatures and endpoints remain the same.
- Day/hour endpoints are `/api/ledgers/day/public` and `/api/ledgers/hour/public`
- Day endpoint returns data on an interval of 1h, therefore 24 datapoints maximum.
- Hour endpoints return on a minute to minute interval, therefore 60 datapoints.
- day interval sample:
```
[
    {
        "date": "06-07 5H",
        "transaction_count": 58341,
        "operation_count": 106878
    },
    {
        "date": "06-07 6H",
        "transaction_count": 224879,
        "operation_count": 477175
    },
]
```

- hour interval sample:
```
[
    {
        "date": "06-08 4H:45M",
        "transaction_count": 3477,
        "operation_count": 5594
    },
    {
        "date": "06-08 4H:46M",
        "transaction_count": 4797,
        "operation_count": 7660
    },
]
```
- Regarding tests, since the functionality itself hasn't changed, only static values depending on the interval, i couldn't see anything new worth testing, our current tests already cover all scenarios i can think of. Let me know if you miss any tests.