### PR TITLE
Feat: Add missing charts for v2.1

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -106,7 +106,7 @@
     "ts-node": "^10.4.0",
     "tsconfig-paths-webpack-plugin": "^3.5.2",
     "webpack": "^5.73.0",
-    "webpack-cli": "^4.9.2",
+    "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.9.1"
   }
 }

--- a/frontend/src/components/NetworkNodes/index.tsx
+++ b/frontend/src/components/NetworkNodes/index.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { useDispatch } from "react-redux";
 
 import { SectionCard } from "components/SectionCard";
-import { AreaChart } from "components/charts/AreaChart";
+import { SimpleAreaChart } from "components/charts/SimpleAreaChart";
 import { fetchNetworkNodesAction } from "ducks/networkNodes";
 import { useRedux } from "hooks/useRedux";
 import { ActionStatus, Network, NetworkNodesType } from "types";
@@ -70,7 +70,7 @@ export const NetworkNodes = ({
               <div className="NetworkNodes__node" key={n.id}>
                 <div className="NetworkNodes__node__label">{n.label}</div>
                 <div className="NetworkNodes__node__chart">
-                  <AreaChart data={data[n.id].historyStats} />
+                  <SimpleAreaChart data={data[n.id].historyStats} />
                 </div>
                 <div className="NetworkNodes__node__count">
                   {data[n.id].current}

--- a/frontend/src/components/charts/AreaChart.tsx
+++ b/frontend/src/components/charts/AreaChart.tsx
@@ -1,0 +1,46 @@
+import { Area } from "recharts";
+
+import { BaseTwoValuesChart } from "./BaseTwoValuesChart";
+import { BaseTwoValuesChartProps } from "./BaseTwoValuesChart/types";
+
+type AreaChartProps = Omit<BaseTwoValuesChartProps, "xContentPaddingEnabled">;
+
+/**
+ * Area Chart component. It is used to display a chart with a series-based data.
+ *
+ * @see {@link BaseTwoValuesChart} for more details on how this data and props work.
+ */
+export const AreaChart = ({
+  primaryValueName,
+  secondaryValueName,
+  primaryValueOnly = false,
+  ...props
+}: AreaChartProps) => {
+  return (
+    <BaseTwoValuesChart primaryValueOnly={primaryValueOnly} {...props}>
+      <Area
+        type="monotone"
+        dataKey="primaryValue"
+        stroke="var(--pal-graph-primary)"
+        fill="var(--pal-graph-primary)"
+        name={primaryValueName}
+        strokeWidth={2}
+      />
+
+      {!primaryValueOnly && (
+        <Area
+          type="monotone"
+          dataKey="secondaryValue"
+          stroke="var(--pal-graph-secondary)"
+          fill="var(--pal-graph-secondary)"
+          name={secondaryValueName}
+          strokeWidth={2}
+        />
+      )}
+    </BaseTwoValuesChart>
+  );
+};
+
+AreaChart.TimeRange = BaseTwoValuesChart.TimeRange;
+
+export const TimeRange = AreaChart.TimeRange;

--- a/frontend/src/components/charts/BaseTwoValuesChart/index.tsx
+++ b/frontend/src/components/charts/BaseTwoValuesChart/index.tsx
@@ -1,0 +1,284 @@
+import { useCallback, useMemo } from "react";
+import {
+  ComposedChart,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip as RechartsTooltip,
+  Legend,
+  ResponsiveContainer,
+  TooltipProps,
+  LegendProps,
+  ReferenceLine,
+  Label,
+} from "recharts";
+import { fromUnixTime } from "date-fns";
+import BigNumber from "bignumber.js";
+
+import { Tooltip } from "components/charts/Tooltip";
+import { useMediaQuery } from "hooks/useMediaQuery";
+
+import {
+  AxisTickProps,
+  LegendContentProps,
+  TimeRange,
+  BaseTwoValuesChartProps,
+  BaseTwoValuesChartTooltipInnerProps,
+} from "./types";
+
+import { dateFormatter, getTimeRangeProps, getTooltipProps } from "./utils";
+
+import "./styles.scss";
+
+const X_AXIS_SMALL_PADDING = 25;
+const X_AXIS_BIG_PADDING = 50;
+const Y_AXIS_MIN_WIDTH = 60;
+const Y_AXIS_WIDTH_MULTIPLIER_VALUE = 12;
+
+/**
+ * Base Two Values-Driven Chart component. It is used to display a chart with a series-based data.
+ * The series should be an array of objects with at least the following properties:
+ *
+ * - date: Date - used for grouping the values
+ * - primaryValue: number - used for the primary value (with color: `--pal-graph-primary`)
+ * - secondaryValue: number - used for the secondary value (with color: `--pal-graph-secondary`)
+ *
+ * You also can pass a `TimeRange` prop, which says how the X-Axis labels will be showed. By default, it is `TimeRange.HOUR`.
+ * Optionally, you can also pass a `baseStartDate` prop, which will be used also to calculate the X-Axis labels.
+ *
+ * P.S: This component is like a base for the AreaChart and the VerticalBarChart components. It was not meant
+ * to be used directly. Instead, you should use one of the other components or create a new one.
+ *
+ * The width and height of the chart are based on the parent container, and the chart take 100% of the space.
+ *
+ * @see BaseTwoValuesChartProps
+ */
+export const BaseTwoValuesChart = ({
+  data,
+  tooltipClassName,
+  timeRange = TimeRange.HOUR,
+  baseStartDate,
+  primaryValueOnly = false,
+  maxLine = false,
+  maxLineOffset = 0,
+  children,
+  xContentPaddingEnabled = false,
+  primaryValueTooltipDescription,
+  secondaryValueTooltipDescription,
+}: BaseTwoValuesChartProps) => {
+  const smallScreen = useMediaQuery("(max-width: 540px)");
+
+  const contentPadding = useMemo(
+    () => (smallScreen ? X_AXIS_SMALL_PADDING : X_AXIS_BIG_PADDING),
+    [smallScreen],
+  );
+
+  const renderTooltip = useCallback(
+    (props: BaseTwoValuesChartTooltipInnerProps) => {
+      if (
+        !props.payload ||
+        (props.payload.length < 2 && !primaryValueOnly) ||
+        (props.payload.length < 1 && primaryValueOnly)
+      ) {
+        return null;
+      }
+
+      const tooltipProps = getTooltipProps(props, {
+        tooltipClassName,
+        timeRange,
+        primaryValueOnly,
+        primaryValueTooltipDescription,
+        secondaryValueTooltipDescription,
+      });
+
+      return <Tooltip {...tooltipProps} />;
+    },
+    [
+      primaryValueOnly,
+      timeRange,
+      tooltipClassName,
+      primaryValueTooltipDescription,
+      secondaryValueTooltipDescription,
+    ],
+  );
+
+  const renderTickXAxis = useCallback(
+    ({ x, y, payload, tickFormatter, index }: AxisTickProps) => {
+      return (
+        <text
+          x={x}
+          y={y}
+          textAnchor="middle"
+          className="BaseTwoValuesChart__y_axis_tick"
+          fill="var(--pal-text-tertiary)"
+        >
+          {tickFormatter
+            ? tickFormatter(payload.value, index)
+            : String(payload.value)}
+        </text>
+      );
+    },
+    [],
+  );
+
+  const renderTickYAxis = useCallback(
+    ({ x, y, payload }: AxisTickProps) => (
+      <text
+        x={x}
+        y={y}
+        className="BaseTwoValuesChart__y_axis_tick"
+        textAnchor="end"
+        fill="var(--pal-text-tertiary)"
+      >
+        {new BigNumber(payload.value).toFormat()}
+      </text>
+    ),
+    [],
+  );
+
+  const renderLegendContent = useCallback(({ payload }: LegendContentProps) => {
+    return (
+      <div className="BaseTwoValuesChart__legend">
+        {payload?.map((entry, index) => (
+          <div
+            key={`item-${index}`}
+            className="BaseTwoValuesChart__legend__item"
+          >
+            <span
+              className="BaseTwoValuesChart__legend__indicator"
+              style={{ backgroundColor: entry.color }}
+            ></span>
+            <span>{entry.value}</span>
+          </div>
+        ))}
+      </div>
+    );
+  }, []);
+
+  const timeRangeData = useMemo(() => {
+    return getTimeRangeProps({
+      timeRange,
+      baseStartDate,
+    });
+  }, [baseStartDate, timeRange]);
+
+  const maxValue = useMemo(
+    () =>
+      Math.max(
+        ...data.map((v) => v.primaryValue),
+        ...(primaryValueOnly ? [] : data.map((v) => v.secondaryValue || 0)),
+      ),
+    [data, primaryValueOnly],
+  );
+
+  const yAxisWidth = useMemo(
+    () =>
+      Math.max(
+        Y_AXIS_MIN_WIDTH,
+        maxValue.toString().length * Y_AXIS_WIDTH_MULTIPLIER_VALUE,
+      ),
+    [maxValue],
+  );
+
+  const renderMaxLine = useMemo(() => {
+    if (typeof maxLine === "number" || maxLine) {
+      const maxLineValue = typeof maxLine === "number" ? maxLine : maxValue;
+      const maxLineLabel = `Max: ${new BigNumber(maxLineValue).toFormat()}`;
+
+      return (
+        <ReferenceLine
+          y={maxLineValue}
+          stroke="var(--pal-brand-primary)"
+          strokeWidth={2}
+          strokeDasharray="5"
+        >
+          <Label className="BaseTwoValuesChart__max_label">
+            {maxLineLabel}
+          </Label>
+        </ReferenceLine>
+      );
+    }
+
+    return null;
+  }, [maxLine, maxValue]);
+
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <ComposedChart
+        className="BaseTwoValuesChart"
+        data={data}
+        barGap={0}
+        barSize={4}
+        barCategoryGap={4}
+      >
+        <CartesianGrid
+          strokeDasharray="3"
+          vertical={false}
+          stroke="var(--pal-border-primary)"
+        />
+        {/* xaxis to add padding to graph container */}
+        <XAxis
+          hide
+          padding={
+            xContentPaddingEnabled
+              ? { left: contentPadding, right: contentPadding }
+              : undefined
+          }
+          dataKey="date"
+          tickLine={false}
+        />
+        {/* xaxis to show labels */}
+        <XAxis
+          padding={{ left: X_AXIS_SMALL_PADDING, right: X_AXIS_SMALL_PADDING }}
+          xAxisId="labelsTime"
+          dataKey="date"
+          interval="preserveStartEnd"
+          stroke="var(--pal-border-primary)"
+          tickLine={false}
+          tickMargin={10}
+          type="number"
+          tick={renderTickXAxis}
+          domain={timeRangeData.domain.map((date) => date.getTime())}
+          tickFormatter={(unixTime) => {
+            const date = fromUnixTime(unixTime / 1000);
+            return dateFormatter(timeRange, date);
+          }}
+          ticks={timeRangeData.ticks.map((date) => date.getTime())}
+        />
+        <YAxis
+          stroke="var(--pal-border-primary)"
+          tickLine={false}
+          tickMargin={10}
+          tick={renderTickYAxis}
+          domain={
+            typeof maxLine === "number"
+              ? [0, maxLine + maxLineOffset]
+              : undefined
+          }
+          width={yAxisWidth}
+        />
+        <RechartsTooltip
+          active
+          allowEscapeViewBox={{ x: true, y: false }}
+          cursor={false}
+          offset={0}
+          content={renderTooltip as TooltipProps<number, string>["content"]}
+        />
+        <Legend
+          verticalAlign="top"
+          align="left"
+          iconType="circle"
+          iconSize={8}
+          content={renderLegendContent as LegendProps["content"]}
+        />
+
+        {children}
+        {renderMaxLine}
+      </ComposedChart>
+    </ResponsiveContainer>
+  );
+};
+
+BaseTwoValuesChart.TimeRange = TimeRange;
+
+export { TimeRange } from "./types";

--- a/frontend/src/components/charts/BaseTwoValuesChart/styles.scss
+++ b/frontend/src/components/charts/BaseTwoValuesChart/styles.scss
@@ -1,4 +1,6 @@
-.VerticalBarChart {
+@import "~styles/functions";
+
+.BaseTwoValuesChart {
   li::before {
     content: "";
   }
@@ -28,5 +30,11 @@
 
   &__y_axis_tick {
     transform: translateY(4px);
+  }
+
+  &__max_label {
+    @include stroke(1, var(--pal-background-primary));
+
+    fill: var(--pal-text-secondary);
   }
 }

--- a/frontend/src/components/charts/BaseTwoValuesChart/types.ts
+++ b/frontend/src/components/charts/BaseTwoValuesChart/types.ts
@@ -1,35 +1,35 @@
-import { SVGProps } from "react";
+import { ReactNode, SVGProps } from "react";
 import { XAxisProps } from "recharts";
 
 /**
- * Item for the VerticalBarChart data
+ * Item for the BaseTwoValuesChart data
  *
  * @prop {Date} date - X-Axis value - Used to group bars
- * @prop {number} primaryValue - Y-Axis primary bar value
- * @prop {number} secondaryValue - Y-Axis secondary bar value
+ * @prop {number} primaryValue - Y-Axis primary value
+ * @prop {number} secondaryValue - Y-Axis secondary value
  * @prop {string} [tooltipTitle] - It will be used as
- *    the tooltip title for the group of bars. If not provided,
+ *    the tooltip title for the group of values. If not provided,
  *    the title will be the date of the group.
  * @prop {string} [tooltipSubtitle] - It will be used as
  *    the tooltip subtitle for the group of bars.
  */
-export type VerticalBarChartDataItem = {
+export type BaseTwoValuesChartItem = {
   tooltipTitle?: string;
   tooltipSubtitle?: string;
   date: Date;
   primaryValue: number;
-  secondaryValue: number;
+  secondaryValue?: number;
 };
 
-export type VerticalBarChartData = VerticalBarChartDataItem[];
+export type BaseTwoValuesChartData = BaseTwoValuesChartItem[];
 
 export type ChartItemPayload = {
   value: number;
   fill: string;
-  payload: VerticalBarChartDataItem;
+  payload: BaseTwoValuesChartItem;
 };
 
-export type VerticalBarChartTooltipInnerProps = {
+export type BaseTwoValuesChartTooltipInnerProps = {
   active?: boolean;
   label?: Date;
   payload?: ChartItemPayload[];
@@ -46,7 +46,7 @@ export type LegendContentProps = {
 };
 
 /**
- * Enum for time range of VerticalBarChart.
+ * Enum for time range of BaseTwoValuesChart.
  */
 export enum TimeRange {
   HOUR = "hour",
@@ -54,7 +54,18 @@ export enum TimeRange {
   MONTH = "month",
 }
 
-export type VerticalBarChartProps = {
+/**
+ * @see BaseTwoValuesChartProps.data
+ * @see BaseTwoValuesChartProps.tooltipClassName
+ * @see BaseTwoValuesChartProps.timeRange
+ * @see BaseTwoValuesChartProps.baseStartDate
+ * @see BaseTwoValuesChartProps.primaryValueOnly
+ * @see BaseTwoValuesChartProps.children
+ * @see BaseTwoValuesChartProps.maxLine
+ * @see BaseTwoValuesChartProps.maxLineOffset
+ * @see BaseTwoValuesChartProps.xContentPaddingEnabled
+ */
+export type BaseTwoValuesChartProps = {
   /**
    * Data to be displayed in the chart.
    *
@@ -64,10 +75,11 @@ export type VerticalBarChartProps = {
    * - primaryValue
    * - secondaryValue
    * - tooltipTitle
+   * - tooltipSubtitle
    *
-   * @see VerticalBarChartDataItem
+   * @see BaseTwoValuesChartItem
    */
-  data: VerticalBarChartData;
+  data: BaseTwoValuesChartData;
   /**
    * Custom CSS class name for the tooltip component.
    */
@@ -108,4 +120,33 @@ export type VerticalBarChartProps = {
    * Date to be used as the base for the X-Axis ticks.
    */
   baseStartDate?: Date;
+  /**
+   * Flag that says if we should use just the primary value to render the bars.
+   */
+  primaryValueOnly?: boolean;
+  /**
+   * Content of the chart. Should be composed by Recharts components.
+   */
+  children?: ReactNode;
+  /**
+   * If the "max line" should be rendered. It can be a boolean, or a number. If `true`,
+   * the max line value will be the max value of the chart, calculated from `primaryValue`
+   * and `secondaryValue`. If a number is provided, it will be used as the max line value.
+   *
+   * @default false
+   */
+  maxLine?: number | boolean;
+  /**
+   * Offset to apply to the top of max line. It has impact on the data domain of Y-Axis.
+   *
+   * @default 0
+   */
+  maxLineOffset?: number;
+  /**
+   * If the X-Axis should have a padding or not, useful to avoid unwanted spacing on
+   * area charts.
+   *
+   * @default false
+   */
+  xContentPaddingEnabled?: boolean;
 };

--- a/frontend/src/components/charts/BaseTwoValuesChart/utils.ts
+++ b/frontend/src/components/charts/BaseTwoValuesChart/utils.ts
@@ -1,7 +1,7 @@
 import {
   TimeRange,
-  VerticalBarChartProps,
-  VerticalBarChartTooltipInnerProps,
+  BaseTwoValuesChartProps,
+  BaseTwoValuesChartTooltipInnerProps,
 } from "./types";
 import { TooltipData } from "../Tooltip";
 import {
@@ -80,27 +80,29 @@ export const dateFormatter = (range: TimeRange, date: Date) => {
  * Helper function to get the props to be used in the tooltip component.
  *
  * It gets the props from the default Recharts Tooltip component, and the `TimeRange`,
- * `tooltipClassName`, `primaryValueTooltipDescription` and `secondaryValueTooltipDescription` props.
+ * `tooltipClassName`, `primaryValueTooltipDescription`, `secondaryValueTooltipDescription` and `primaryValueOnly` props.
  *
  * It returns an object containing the props to be used in the ChartTooltip component (our Tooltip, not Recharts' one).
  *
  * @see {@link https://recharts.org/en-US/api/Tooltip}
- * @see VerticalBarChartProps.timeRange
- * @see VerticalBarChartProps.tooltipClassName
- * @see VerticalBarChartProps.primaryValueTooltipDescription
- * @see VerticalBarChartProps.secondaryValueTooltipDescription
+ * @see BaseTwoValuesChartProps.timeRange
+ * @see BaseTwoValuesChartProps.tooltipClassName
+ * @see BaseTwoValuesChartProps.primaryValueTooltipDescription
+ * @see BaseTwoValuesChartProps.secondaryValueTooltipDescription
  */
 export const getTooltipProps = (
-  { active, label, payload }: VerticalBarChartTooltipInnerProps,
+  { active, label, payload }: BaseTwoValuesChartTooltipInnerProps,
   {
     timeRange = TimeRange.HOUR,
     tooltipClassName,
+    primaryValueOnly,
     primaryValueTooltipDescription,
     secondaryValueTooltipDescription,
   }: Pick<
-    VerticalBarChartProps,
+    BaseTwoValuesChartProps,
     | "timeRange"
     | "tooltipClassName"
+    | "primaryValueOnly"
     | "primaryValueTooltipDescription"
     | "secondaryValueTooltipDescription"
   >,
@@ -116,7 +118,9 @@ export const getTooltipProps = (
   }
 
   const primaryLabel = new BigNumber(primaryData.value!).toFormat();
-  const secondaryLabel = new BigNumber(secondaryData.value!).toFormat();
+  const secondaryLabel = primaryValueOnly
+    ? null
+    : new BigNumber(secondaryData?.value!).toFormat();
 
   if (primaryValueTooltipDescription) {
     primaryValueTooltipDescription = ` ${primaryValueTooltipDescription}`;
@@ -132,10 +136,12 @@ export const getTooltipProps = (
         label: `${primaryLabel}${primaryValueTooltipDescription || ""}`,
         fill: primaryData?.fill,
       },
-      {
-        label: `${secondaryLabel}${secondaryValueTooltipDescription || ""}`,
-        fill: secondaryData?.fill,
-      },
+      primaryValueOnly
+        ? null
+        : {
+            label: `${secondaryLabel}${secondaryValueTooltipDescription || ""}`,
+            fill: secondaryData?.fill,
+          },
     ] as TooltipData,
     active,
     tooltipTitle,
@@ -157,13 +163,13 @@ const EMPTY_TIME_RANGE_PROPS = {
  * @returns An object containing the attribute `ticks`, which is an Array/Tuple of 5 ticks (dates),
  *      and the attribute `domain`, which is a Tuple of 2 dates - the start and the end of the domain
  *
- * @see VerticalBarChartProps.timeRange
- * @see VerticalBarChartProps.baseStartDate
+ * @see BaseTwoValuesChartProps.timeRange
+ * @see BaseTwoValuesChartProps.baseStartDate
  */
 export const getTimeRangeProps = ({
   timeRange,
   baseStartDate,
-}: Pick<VerticalBarChartProps, "timeRange" | "baseStartDate">) => {
+}: Pick<BaseTwoValuesChartProps, "timeRange" | "baseStartDate">) => {
   if (!timeRange) {
     return EMPTY_TIME_RANGE_PROPS;
   }

--- a/frontend/src/components/charts/SimpleAreaChart.tsx
+++ b/frontend/src/components/charts/SimpleAreaChart.tsx
@@ -11,7 +11,7 @@ type Props = {
 };
 
 /**
- * Area chart component. It is used to display a chart with a series-based data.
+ * Simple Area chart component. It is used to display a chart with a series-based data.
  * The series should be an array of objects with the following properties:
  *
  * - name: string
@@ -21,7 +21,7 @@ type Props = {
  *
  * The width and height of the chart are based on the parent container, and the chart take 100% of the space.
  */
-export const AreaChart = ({ data }: Props) => {
+export const SimpleAreaChart = ({ data }: Props) => {
   return (
     <ResponsiveContainer width="100%" height="100%">
       <RechartsArea data={data}>

--- a/frontend/src/components/charts/Tooltip/index.tsx
+++ b/frontend/src/components/charts/Tooltip/index.tsx
@@ -68,17 +68,19 @@ export const Tooltip = ({
                   {tooltipSubtitle}
                 </div>
               )}
-              {data.map((entry) => (
-                <div key={entry.label} className="ChartTooltip__content__row">
-                  <div
-                    className="ChartTooltip__content__row__circle"
-                    style={{
-                      backgroundColor: entry.fill,
-                    }}
-                  ></div>
-                  <div>{entry.label}</div>
-                </div>
-              ))}
+              {data
+                .filter((entry) => !!entry)
+                .map((entry) => (
+                  <div key={entry.label} className="ChartTooltip__content__row">
+                    <div
+                      className="ChartTooltip__content__row__circle"
+                      style={{
+                        backgroundColor: entry.fill,
+                      }}
+                    ></div>
+                    <div>{entry.label}</div>
+                  </div>
+                ))}
             </div>
           }
           position={StellarTooltip.position.RIGHT}

--- a/frontend/src/components/charts/VerticalBarChart/index.tsx
+++ b/frontend/src/components/charts/VerticalBarChart/index.tsx
@@ -1,248 +1,52 @@
-import { useCallback, useMemo } from "react";
-import {
-  BarChart,
-  Bar,
-  XAxis,
-  YAxis,
-  CartesianGrid,
-  Tooltip as RechartsTooltip,
-  Legend,
-  ResponsiveContainer,
-  TooltipProps,
-  LegendProps,
-} from "recharts";
-import { fromUnixTime } from "date-fns";
-import BigNumber from "bignumber.js";
-
-import { Tooltip } from "components/charts/Tooltip";
-import { useMediaQuery } from "hooks/useMediaQuery";
+import { Bar } from "recharts";
 
 import { VerticalBarShape } from "./VerticalBarShape";
 
-import {
-  AxisTickProps,
-  LegendContentProps,
-  TimeRange,
-  VerticalBarChartProps,
-  VerticalBarChartTooltipInnerProps,
-} from "./types";
+import { BaseTwoValuesChart } from "../BaseTwoValuesChart";
+import { BaseTwoValuesChartProps } from "../BaseTwoValuesChart/types";
 
-import { dateFormatter, getTimeRangeProps, getTooltipProps } from "./utils";
-
-import "./styles.scss";
-
-const X_AXIS_SMALL_PADDING = 25;
-const X_AXIS_BIG_PADDING = 50;
-const Y_AXIS_MIN_WIDTH = 60;
-const Y_AXIS_WIDTH_MULTIPLIER_VALUE = 12;
+type VerticalBarChartProps = Omit<
+  BaseTwoValuesChartProps,
+  "xContentPaddingEnabled"
+>;
 
 /**
  * Vertical Bar Chart component. It is used to display a chart with a series-based data.
- * The series should be an array of objects with at least the following properties:
  *
- * - date: Date - used for grouping the bars
- * - primaryValue: number - used for the primary bar (with color: `--pal-graph-primary`)
- * - secondaryValue: number - used for the secondary bar (with color: `--pal-graph-secondary`)
- *
- * You also can pass a `TimeRange` prop, which says how the X-Axis labels will be showed. By default, it is `TimeRange.HOUR`.
- * Optionally, you can also pass a `baseStartDate` prop, which will be used also to calculate the X-Axis labels.
- *
- * The width and height of the chart are based on the parent container, and the chart take 100% of the space.
+ * @see {@link BaseTwoValuesChart} for more details on how this data and props work.
  */
 export const VerticalBarChart = ({
-  data,
-  tooltipClassName,
-
   primaryValueName,
   secondaryValueName,
-
-  timeRange = TimeRange.HOUR,
-  baseStartDate,
-  primaryValueTooltipDescription,
-  secondaryValueTooltipDescription,
+  primaryValueOnly = false,
+  ...props
 }: VerticalBarChartProps) => {
-  const smallScreen = useMediaQuery("(max-width: 540px)");
-
-  const contentPadding = useMemo(
-    () => (smallScreen ? X_AXIS_SMALL_PADDING : X_AXIS_BIG_PADDING),
-    [smallScreen],
-  );
-
-  const renderTooltip = useCallback(
-    (props: VerticalBarChartTooltipInnerProps) => {
-      if (!props.payload || props.payload.length < 2) {
-        return null;
-      }
-
-      const tooltipProps = getTooltipProps(props, {
-        tooltipClassName,
-        timeRange,
-        primaryValueTooltipDescription,
-        secondaryValueTooltipDescription,
-      });
-
-      return <Tooltip {...tooltipProps} />;
-    },
-    [
-      timeRange,
-      tooltipClassName,
-      primaryValueTooltipDescription,
-      secondaryValueTooltipDescription,
-    ],
-  );
-
-  const renderTickXAxis = useCallback(
-    ({ x, y, payload, tickFormatter, index }: AxisTickProps) => {
-      return (
-        <text
-          x={x}
-          y={y}
-          textAnchor="middle"
-          className="VerticalBarChart__y_axis_tick"
-          fill="var(--pal-text-tertiary)"
-        >
-          {tickFormatter
-            ? tickFormatter(payload.value, index)
-            : String(payload.value)}
-        </text>
-      );
-    },
-    [],
-  );
-
-  const renderTickYAxis = useCallback(
-    ({ x, y, payload }: AxisTickProps) => (
-      <text
-        x={x}
-        y={y}
-        className="VerticalBarChart__y_axis_tick"
-        textAnchor="end"
-        fill="var(--pal-text-tertiary)"
-      >
-        {new BigNumber(payload.value).toFormat()}
-      </text>
-    ),
-    [],
-  );
-
-  const renderLegendContent = useCallback(({ payload }: LegendContentProps) => {
-    return (
-      <div className="VerticalBarChart__legend">
-        {payload?.map((entry, index) => (
-          <div key={`item-${index}`} className="VerticalBarChart__legend__item">
-            <span
-              className="VerticalBarChart__legend__indicator"
-              style={{ backgroundColor: entry.color }}
-            ></span>
-            <span>{entry.value}</span>
-          </div>
-        ))}
-      </div>
-    );
-  }, []);
-
-  const timeRangeData = useMemo(() => {
-    return getTimeRangeProps({
-      timeRange,
-      baseStartDate,
-    });
-  }, [baseStartDate, timeRange]);
-
-  const maxValue = useMemo(
-    () =>
-      Math.max(
-        ...data.map((v) => v.primaryValue),
-        ...data.map((v) => v.secondaryValue),
-      ),
-    [data],
-  );
-
-  const yAxisWidth = useMemo(
-    () =>
-      Math.max(
-        Y_AXIS_MIN_WIDTH,
-        maxValue.toString().length * Y_AXIS_WIDTH_MULTIPLIER_VALUE,
-      ),
-    [maxValue],
-  );
-
   return (
-    <ResponsiveContainer width="100%" height="100%">
-      <BarChart
-        className="VerticalBarChart"
-        data={data}
-        barGap={0}
-        barSize={4}
-        barCategoryGap={4}
-      >
-        <CartesianGrid
-          strokeDasharray="3"
-          vertical={false}
-          stroke="var(--pal-border-primary)"
-        />
-        {/* xaxis to add padding to graph container */}
-        <XAxis
-          hide
-          padding={{ left: contentPadding, right: contentPadding }}
-          dataKey="date"
-          tickLine={false}
-        />
-        {/* xaxis to show labels */}
-        <XAxis
-          padding={{ left: X_AXIS_SMALL_PADDING, right: X_AXIS_SMALL_PADDING }}
-          xAxisId="labelsTime"
-          dataKey="date"
-          interval="preserveStartEnd"
-          stroke="var(--pal-border-primary)"
-          tickLine={false}
-          tickMargin={10}
-          type="number"
-          tick={renderTickXAxis}
-          domain={timeRangeData.domain.map((date) => date.getTime())}
-          tickFormatter={(unixTime) => {
-            const date = fromUnixTime(unixTime / 1000);
-            return dateFormatter(timeRange, date);
-          }}
-          ticks={timeRangeData.ticks.map((date) => date.getTime())}
-        />
-        <YAxis
-          stroke="var(--pal-border-primary)"
-          tickLine={false}
-          tickMargin={10}
-          tick={renderTickYAxis}
-          width={yAxisWidth}
-        />
-        <RechartsTooltip
-          active
-          allowEscapeViewBox={{ x: true, y: false }}
-          cursor={false}
-          offset={0}
-          content={renderTooltip as TooltipProps<number, string>["content"]}
-        />
-        <Legend
-          verticalAlign="top"
-          align="left"
-          iconType="circle"
-          iconSize={8}
-          content={renderLegendContent as LegendProps["content"]}
-        />
+    <BaseTwoValuesChart
+      primaryValueOnly={primaryValueOnly}
+      xContentPaddingEnabled
+      {...props}
+    >
+      <>
         <Bar
           dataKey="primaryValue"
           fill="var(--pal-graph-primary)"
           shape={(props) => <VerticalBarShape {...props} valueIndex={0} />}
           name={primaryValueName}
         />
-        <Bar
-          dataKey="secondaryValue"
-          fill="var(--pal-graph-secondary)"
-          shape={(props) => <VerticalBarShape {...props} valueIndex={1} />}
-          name={secondaryValueName}
-        />
-      </BarChart>
-    </ResponsiveContainer>
+        {!primaryValueOnly && (
+          <Bar
+            dataKey="secondaryValue"
+            fill="var(--pal-graph-secondary)"
+            shape={(props) => <VerticalBarShape {...props} valueIndex={1} />}
+            name={secondaryValueName}
+          />
+        )}
+      </>
+    </BaseTwoValuesChart>
   );
 };
 
-VerticalBarChart.TimeRange = TimeRange;
+VerticalBarChart.TimeRange = BaseTwoValuesChart.TimeRange;
 
-export { TimeRange } from "./types";
+export const TimeRange = VerticalBarChart.TimeRange;

--- a/frontend/src/styles/functions.scss
+++ b/frontend/src/styles/functions.scss
@@ -1,0 +1,21 @@
+/// Stroke font-character
+/// @param  {Integer} $stroke - Stroke width
+/// @param  {Color}   $color  - Stroke color
+/// @return {List}            - text-shadow list
+@function stroke($stroke, $color) {
+  $shadow: ();
+  $from: $stroke * -1;
+  @for $i from $from through $stroke {
+    @for $j from $from through $stroke {
+      $shadow: append($shadow, $i * 1px $j * 1px 0 $color, comma);
+    }
+  }
+  @return $shadow;
+}
+/// Stroke font-character
+/// @param  {Integer} $stroke - Stroke width
+/// @param  {Color}   $color  - Stroke color
+/// @return {Style}           - text-shadow
+@mixin stroke($stroke, $color) {
+  text-shadow: stroke($stroke, $color);
+}

--- a/frontend/webpack.common.js
+++ b/frontend/webpack.common.js
@@ -115,6 +115,9 @@ module.exports = {
   },
   resolve: {
     extensions: [".tsx", ".ts", ".js"],
+    alias: {
+      styles: path.join(__dirname, "src/styles"),
+    },
     plugins: [
       // This handles aliases and resolves Design System CSS font paths properly
       new TsconfigPathsPlugin({

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2032,22 +2032,22 @@
     "@webassemblyjs/ast" "1.11.1"
     "@xtuc/long" "4.2.2"
 
-"@webpack-cli/configtest@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@webpack-cli/configtest/-/configtest-1.1.1.tgz#9f53b1b7946a6efc2a749095a4f450e2932e8356"
-  integrity sha512-1FBc1f9G4P/AxMqIgfZgeOTuRnwZMten8E7zap5zgpPInnCrP8D4Q81+4CWIch8i/Nf7nXjP0v6CjjbHOrXhKg==
+"@webpack-cli/configtest@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@webpack-cli/configtest/-/configtest-1.2.0.tgz#7b20ce1c12533912c3b217ea68262365fa29a6f5"
+  integrity sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==
 
-"@webpack-cli/info@^1.4.1":
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/@webpack-cli/info/-/info-1.4.1.tgz#2360ea1710cbbb97ff156a3f0f24556e0fc1ebea"
-  integrity sha512-PKVGmazEq3oAo46Q63tpMr4HipI3OPfP7LiNOEJg963RMgT0rqheag28NCML0o3GIzA3DmxP1ZIAv9oTX1CUIA==
+"@webpack-cli/info@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@webpack-cli/info/-/info-1.5.0.tgz#6c78c13c5874852d6e2dd17f08a41f3fe4c261b1"
+  integrity sha512-e8tSXZpw2hPl2uMJY6fsMswaok5FdlGNRTktvFk2sD8RjH0hE2+XistawJx1vmKteh4NmGmNUrp+Tb2w+udPcQ==
   dependencies:
     envinfo "^7.7.3"
 
-"@webpack-cli/serve@^1.6.1":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-1.6.1.tgz#0de2875ac31b46b6c5bb1ae0a7d7f0ba5678dffe"
-  integrity sha512-gNGTiTrjEVQ0OcVnzsRSqTxaBSr+dmTfm+qJsCDluky8uhdLWep7Gcr62QsAKHTMxjCS/8nEITsmFAhfIx+QSw==
+"@webpack-cli/serve@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-1.7.0.tgz#e1993689ac42d2b16e9194376cfb6753f6254db1"
+  integrity sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -8105,18 +8105,18 @@ wbuf@^1.1.0, wbuf@^1.7.3:
   dependencies:
     minimalistic-assert "^1.0.0"
 
-webpack-cli@^4.9.2:
-  version "4.9.2"
-  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-4.9.2.tgz#77c1adaea020c3f9e2db8aad8ea78d235c83659d"
-  integrity sha512-m3/AACnBBzK/kMTcxWHcZFPrw/eQuY4Df1TxvIWfWM2x7mRqBQCqKEd96oCUa9jkapLBaFfRce33eGDb4Pr7YQ==
+webpack-cli@^4.10.0:
+  version "4.10.0"
+  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-4.10.0.tgz#37c1d69c8d85214c5a65e589378f53aec64dab31"
+  integrity sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==
   dependencies:
     "@discoveryjs/json-ext" "^0.5.0"
-    "@webpack-cli/configtest" "^1.1.1"
-    "@webpack-cli/info" "^1.4.1"
-    "@webpack-cli/serve" "^1.6.1"
+    "@webpack-cli/configtest" "^1.2.0"
+    "@webpack-cli/info" "^1.5.0"
+    "@webpack-cli/serve" "^1.7.0"
     colorette "^2.0.14"
     commander "^7.0.0"
-    execa "^5.0.0"
+    cross-spawn "^7.0.3"
     fastest-levenshtein "^1.0.12"
     import-local "^3.0.2"
     interpret "^2.2.0"


### PR DESCRIPTION
Add missing charts for v2.1:
- AreaChart driven by two values
- VerticalBarChart should have the ability to show just the primary value
- Older AreaChart was renamed to SimpleAreaChart to make things more clear
- A BaseTwoValueChart component was created to encapsulate most of the common behavior between AreaChart and VerticalBarChart
- Ability to show a max line on BaseTwoValueChart "descendants"

There are some screenshots in the comments [here (#275)](https://github.com/stellar/dashboard/issues/275#issuecomment-1151458690) and [here (#273)](https://github.com/stellar/dashboard/issues/273#issuecomment-1151469537)