### PR TITLE
Fix: ledger api link

### DIFF
--- a/frontend/src/components/LedgerInfo/index.tsx
+++ b/frontend/src/components/LedgerInfo/index.tsx
@@ -121,7 +121,7 @@ export const LedgerInfo = ({
     <SectionCard
       title="Ledger Info"
       titleLinkLabel="API"
-      titleLink={`/api/ledgers${ledgerTransactionHistoryConfig[selectedTimeInterval].endpointPrefix}/public${networkConfig[network].ledgerTransactionsHistorySuffix}`}
+      titleLink={`/api/ledgers${ledgerTransactionHistoryConfig[selectedTimeInterval].endpointPrefix}${networkConfig[network].ledgerTransactionsHistorySuffix}`}
       titleCustom={graphNavOptionsContent}
       isLoading={status === ActionStatus.PENDING}
       noData={!itemsData.length}


### PR DESCRIPTION
Fix ledger API link. It was rendering `/public/public` instead of just `/public`.