### PR TITLE
Get operations stats from ledger history

### DIFF
--- a/backend/src/ledgers/data.ts
+++ b/backend/src/ledgers/data.ts
@@ -262,7 +262,7 @@ export async function getOpStats() {
   const query = `
     SELECT 
       FORMAT_DATE('%Y-%m', cast(closed_at as date)) as closing_date,
-      SUM(operation_count) as operations 
+      SUM(tx_set_operation_count) as operations 
     FROM ${bigQueryEndpointBase}.history_ledgers 
     GROUP BY closing_date 
     ORDER BY closing_date

--- a/backend/src/ledgers/data.ts
+++ b/backend/src/ledgers/data.ts
@@ -13,6 +13,7 @@ import {
   getServerNamespace,
 } from "./utils";
 import { findIndex } from "lodash";
+import { bigQueryEndpointBase, fetchCachedData } from "../utils";
 
 const intervalTypes = [INTERVALS.hour, INTERVALS.day, INTERVALS.month];
 const CURSOR_NOW = "now";
@@ -255,4 +256,19 @@ export async function updateCache(
     JSON.stringify(cachedStats.slice(0, LEDGER_ITEM_LIMIT[interval])),
   );
   await redisClient.set(pagingTokenKey, pagingToken);
+}
+
+export async function getOpStats() {
+  const query = `
+    SELECT 
+      FORMAT_DATE('%Y-%m', cast(closed_at as date)) as closing_date,
+      SUM(operation_count) as operations 
+    FROM ${bigQueryEndpointBase}.history_ledgers 
+    GROUP BY closing_date 
+    ORDER BY closing_date
+  `;
+
+  const output = await fetchCachedData("ledger-operation-stats", query);
+
+  return output;
 }

--- a/backend/src/ledgers/index.ts
+++ b/backend/src/ledgers/index.ts
@@ -1,7 +1,7 @@
 import { Response, NextFunction } from "express";
 
 import { redisClient, getOrThrow } from "../redisSetup";
-import { REDIS_LEDGER_KEYS } from "./data";
+import { getOpStats, REDIS_LEDGER_KEYS } from "./data";
 import { formatOutput, getServerNamespace, LedgerStat } from "./utils";
 
 export async function handler_month(_: any, res: Response, next: NextFunction) {
@@ -74,6 +74,18 @@ export async function handler_hour_testnet(
     const cachedData = await getOrThrow(redisClient, REDIS_LEDGER_KEY);
     const ledgers: LedgerStat[] = JSON.parse(cachedData);
     res.json(formatOutput(ledgers));
+  } catch (e) {
+    next(e);
+  }
+}
+
+export async function getOperationStats(
+  _: any,
+  res: Response,
+  next: NextFunction,
+) {
+  try {
+    return res.json(await getOpStats());
   } catch (e) {
     next(e);
   }

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -35,6 +35,7 @@ app.get("/api/ledgers/month/public", ledgers.handler_month);
 app.get("/api/ledgers/hour/testnet", ledgers.handler_hour_testnet);
 app.get("/api/ledgers/day/testnet", ledgers.handler_day_testnet);
 app.get("/api/ledgers/month/testnet", ledgers.handler_month_testnet);
+app.get("/api/ledgers/op_stats", ledgers.getOperationStats);
 app.get("/api/lumens", lumens.v1Handler);
 
 app.get("/api/dex/24h-payments", dex.get24hPaymentsData);


### PR DESCRIPTION
Adds new endpoint `/api/ledgers/op_stats`, it returns operations sorted by month. Starts on 2015, ends on current month. Sample output:
![image](https://user-images.githubusercontent.com/8282304/180249571-0e222466-81bc-4e5e-9e65-5653cb770150.png)


The query is pretty fast actually, takes about 4 seconds. The worry i had for long executing queries was because i thought we wanted a similar system to what we have for other ledgers.

I think when we implement the redis CRON jobs, we can clear out this key as well whenever we want more updated results. The key is `ledger-operation-stats`. Let me know if you want any improvements in this PR @acharb 