### PR TITLE
add script for refreshing redis to be run by cronjob

### DIFF
--- a/backend/__tests__/lumens.test.ts
+++ b/backend/__tests__/lumens.test.ts
@@ -1,4 +1,4 @@
-import { redisClient } from "../src/redisSetup";
+import { redisClient } from "../src/redis/redisSetup";
 import { updateCache, catchup, LedgerRecord } from "../src/ledgers/data";
 import { INTERVALS } from "../src/ledgers/utils";
 import { updateApiLumens as updateApiLumensV1 } from "../src/lumens";

--- a/backend/__tests__/routes.test.ts
+++ b/backend/__tests__/routes.test.ts
@@ -1,5 +1,5 @@
 import request from "supertest";
-import { redisClient } from "../src/redisSetup";
+import { redisClient } from "../src/redis/redisSetup";
 import { app, updateLumensCache } from "../src/routes";
 
 describe("integration", () => {

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,7 +11,9 @@
     "start": "UPDATE_DATA=true DEV=true ts-node ./src/app.ts",
     "clean": "rm -rf node_modules && rm -rf build",
     "test": "jest --forceExit",
-    "build": "tsc --project ."
+    "build": "tsc --project .",
+    "redis:reset_day": "ts-node ./src/redis/redisRefresh.ts day",
+    "redis:reset_month": "ts-node ./src/redis/redisRefresh.ts month"
   },
   "dependencies": {
     "@google-cloud/bigquery": "^5.11.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,8 +12,8 @@
     "clean": "rm -rf node_modules && rm -rf build",
     "test": "jest --forceExit",
     "build": "tsc --project .",
-    "redis:reset_day": "ts-node ./src/redis/redisRefresh.ts day",
-    "redis:reset_month": "ts-node ./src/redis/redisRefresh.ts month"
+    "redis:reset_day": "DEV=true ts-node ./src/redis/redisRefresh.ts day",
+    "redis:reset_month": "DEV=true ts-node ./src/redis/redisRefresh.ts month"
   },
   "dependencies": {
     "@google-cloud/bigquery": "^5.11.0",

--- a/backend/src/fees/data.ts
+++ b/backend/src/fees/data.ts
@@ -1,5 +1,10 @@
 import { bigQueryEndpointBase, fetchCachedData } from "../utils";
 
+export const REDIS_FEES_KEYS = {
+  FEES_MONTH: "fees-month",
+  FEES_DAY: "fees-day",
+};
+
 export async function getFeesData30d() {
   const query = `
     SELECT 
@@ -15,7 +20,7 @@ export async function getFeesData30d() {
     ORDER BY closing_date
   `;
 
-  const data = await fetchCachedData("fees-month", query);
+  const data = await fetchCachedData(REDIS_FEES_KEYS.FEES_MONTH, query);
   const output = data.map((fee) => {
     return {
       ...fee,
@@ -39,7 +44,7 @@ export async function getFeesData1d() {
     GROUP BY closing_hour
     ORDER BY closing_hour
   `;
-  const data = await fetchCachedData("fees-day", query);
+  const data = await fetchCachedData(REDIS_FEES_KEYS.FEES_DAY, query);
 
   const output = data.map((fee) => {
     return {

--- a/backend/src/ledgers/data.ts
+++ b/backend/src/ledgers/data.ts
@@ -1,7 +1,7 @@
 import { QueryRowsResponse } from "@google-cloud/bigquery";
 import stellarSdk from "stellar-sdk";
 
-import { redisClient } from "../redisSetup";
+import { redisClient } from "../redis/redisSetup";
 import { bqClient, BQHistoryLedger, getBqQueryByDate } from "../bigQuery";
 import {
   BIGQUERY_DATES,
@@ -40,6 +40,7 @@ export const REDIS_LEDGER_KEYS = {
   hour: "ledgers_hour",
   day: "ledgers_day",
   month: "ledgers_month",
+  operation_stats: "ledger-operation-stats",
 };
 
 interface sum {
@@ -268,7 +269,10 @@ export async function getOpStats() {
     ORDER BY closing_date
   `;
 
-  const output = await fetchCachedData("ledger-operation-stats", query);
+  const output = await fetchCachedData(
+    REDIS_LEDGER_KEYS.operation_stats,
+    query,
+  );
 
   return output;
 }

--- a/backend/src/ledgers/index.ts
+++ b/backend/src/ledgers/index.ts
@@ -1,6 +1,6 @@
 import { Response, NextFunction } from "express";
 
-import { redisClient, getOrThrow } from "../redisSetup";
+import { redisClient, getOrThrow } from "../redis/redisSetup";
 import { getOpStats, REDIS_LEDGER_KEYS } from "./data";
 import { formatOutput, getServerNamespace, LedgerStat } from "./utils";
 

--- a/backend/src/lumens.ts
+++ b/backend/src/lumens.ts
@@ -1,5 +1,5 @@
 import { Response, NextFunction } from "express";
-import { redisClient, getOrThrow } from "./redisSetup";
+import { redisClient, getOrThrow } from "./redis/redisSetup";
 import * as commonLumens from "../../common/lumens.js";
 
 interface CachedData {

--- a/backend/src/redis/redisRefresh.ts
+++ b/backend/src/redis/redisRefresh.ts
@@ -1,0 +1,50 @@
+import { redisClient } from "./redisSetup";
+import {
+  getPaymentsData,
+  getTradeData,
+  getUniqueAssetsData,
+  getActiveAccountsData,
+  REDIS_DEX_KEYS,
+} from "../dex/data";
+import { getFeesData30d, getFeesData1d, REDIS_FEES_KEYS } from "../fees/data";
+import { getOpStats, REDIS_LEDGER_KEYS } from "../ledgers/data";
+
+const DAY = "day";
+const MONTH = "month";
+
+(async () => {
+  let resetKeys = [];
+  if (process.argv[2] === DAY) {
+    const resetKeys = [
+      REDIS_FEES_KEYS.FEES_DAY,
+      REDIS_FEES_KEYS.FEES_MONTH,
+      REDIS_DEX_KEYS.PAYMENTS_24H,
+      REDIS_DEX_KEYS.DEX_TRADES_24H,
+      REDIS_DEX_KEYS.DEX_TRADES_48H,
+      REDIS_DEX_KEYS.DEX_TRADES_OVERALL,
+      REDIS_DEX_KEYS.DEX_UNIQUE_ASSETS,
+      REDIS_DEX_KEYS.DEX_ACTIVE_ACCOUNTS,
+    ];
+  } else if (process.argv[2] === MONTH) {
+    resetKeys = [REDIS_LEDGER_KEYS.operation_stats];
+  }
+
+  for (const k of resetKeys) {
+    await redisClient.del(k);
+    console.log("cleared redis key:", k);
+  }
+
+  // lets refresh the redis data by calling BQ from here
+  if (process.argv[2] === DAY) {
+    await getFeesData30d();
+    await getFeesData1d();
+    await getPaymentsData();
+    await getTradeData();
+    await getUniqueAssetsData();
+    await getActiveAccountsData();
+  } else if (process.argv[2] === MONTH) {
+    await getOpStats();
+  }
+
+  await redisClient.quit();
+})();

--- a/backend/src/redis/redisRefresh.ts
+++ b/backend/src/redis/redisRefresh.ts
@@ -15,7 +15,7 @@ const MONTH = "month";
 (async () => {
   let resetKeys = [];
   if (process.argv[2] === DAY) {
-    const resetKeys = [
+    resetKeys = [
       REDIS_FEES_KEYS.FEES_DAY,
       REDIS_FEES_KEYS.FEES_MONTH,
       REDIS_DEX_KEYS.PAYMENTS_24H,

--- a/backend/src/redis/redisSetup.ts
+++ b/backend/src/redis/redisSetup.ts
@@ -34,7 +34,3 @@ export async function getOrThrow(
   }
   return cachedData;
 }
-
-export async function clearRedisData(rc: RedisClientType, key: string) {
-  rc.del(key);
-}

--- a/backend/src/redis/redisSetup.ts
+++ b/backend/src/redis/redisSetup.ts
@@ -34,3 +34,7 @@ export async function getOrThrow(
   }
   return cachedData;
 }
+
+export async function clearRedisData(rc: RedisClientType, key: string) {
+  rc.del(key);
+}

--- a/backend/src/utils.ts
+++ b/backend/src/utils.ts
@@ -1,5 +1,5 @@
 import { bqClient } from "./bigQuery";
-import { getOrThrow, redisClient } from "./redisSetup";
+import { getOrThrow, redisClient } from "./redis/redisSetup";
 
 export const bigQueryEndpointBase = "crypto-stellar.crypto_stellar_2";
 

--- a/backend/src/v2v3/lumens.ts
+++ b/backend/src/v2v3/lumens.ts
@@ -1,6 +1,6 @@
 import BigNumber from "bignumber.js";
 import { Response, NextFunction } from "express";
-import { redisClient, getOrThrow } from "../redisSetup";
+import { redisClient, getOrThrow } from "../redis/redisSetup";
 import * as commonLumens from "../../../common/lumens.js";
 
 const LUMEN_SUPPLY_METRICS_URL =


### PR DESCRIPTION
some of the new v2 endpoints (dex, fees, ledger op stats) have data that updates when redis is cleared, so adding the code to do that that will be triggered by a cron job