### PR TITLE
use process.exit() for redis refresh script

### DIFF
--- a/backend/src/redis/redisRefresh.ts
+++ b/backend/src/redis/redisRefresh.ts
@@ -46,5 +46,5 @@ const MONTH = "month";
     await getOpStats();
   }
 
-  await redisClient.quit();
+  process.exit();
 })();


### PR DESCRIPTION
calling redis.close twice, here and in [redisSetup](https://github.com/stellar/dashboard/blob/b661fb1d1216b61f2497262b6bec1c3f0dc9ed66/backend/src/redis/redisSetup.ts#L22) . Using process.exit() ends the script process which then will close redis

should fix the cron job errors mentioned [here](https://stellarfoundation.slack.com/archives/C02U19A2A/p1662044682319789?thread_ts=1660926095.720359&cid=C02U19A2A)