### PR TITLE
link to op_stats in total monthly operations chart

### DIFF
--- a/frontend/src/components/LumenSupply/index.tsx
+++ b/frontend/src/components/LumenSupply/index.tsx
@@ -107,7 +107,6 @@ export const LumenSupply = ({
       titleLink="https://developers.stellar.org/docs/glossary/lumen-supply/"
       isLoading={lumenSupply.status === ActionStatus.PENDING}
       noData={!data}
-      noShadow
     >
       {data ? (
         <div className="LumenSupply">

--- a/frontend/src/components/LumenSupply/index.tsx
+++ b/frontend/src/components/LumenSupply/index.tsx
@@ -107,6 +107,7 @@ export const LumenSupply = ({
       titleLink="https://developers.stellar.org/docs/glossary/lumen-supply/"
       isLoading={lumenSupply.status === ActionStatus.PENDING}
       noData={!data}
+      noShadow={network === Network.MAINNET}
     >
       {data ? (
         <div className="LumenSupply">

--- a/frontend/src/components/NetworkNodes/index.tsx
+++ b/frontend/src/components/NetworkNodes/index.tsx
@@ -64,7 +64,6 @@ export const NetworkNodes = ({
       isLoading={networkNodes.status === ActionStatus.PENDING}
       noData={!data}
       marginTop="1rem"
-      noShadow
     >
       <div className="NetworkNodes">
         {data

--- a/frontend/src/components/NetworkNodes/index.tsx
+++ b/frontend/src/components/NetworkNodes/index.tsx
@@ -64,6 +64,7 @@ export const NetworkNodes = ({
       isLoading={networkNodes.status === ActionStatus.PENDING}
       noData={!data}
       marginTop="1rem"
+      noShadow={network === Network.MAINNET}
     >
       <div className="NetworkNodes">
         {data

--- a/frontend/src/components/RecentOperations/index.tsx
+++ b/frontend/src/components/RecentOperations/index.tsx
@@ -80,7 +80,6 @@ export const RecentOperations = ({
       title="Recent Operations: Live Network"
       titleLinkLabel="API"
       titleLink={`${horizonURL}/operations?order=desc&limit=20`}
-      noShadow
     >
       <Table
         id="last-10-operations"

--- a/frontend/src/components/RecentOperations/index.tsx
+++ b/frontend/src/components/RecentOperations/index.tsx
@@ -14,8 +14,10 @@ import { FetchLastOperationsActionResponse, Network } from "types";
 
 export const RecentOperations = ({
   network = Network.MAINNET,
+  noShadow = false,
 }: {
   network?: Network;
+  noShadow?: boolean;
 }) => {
   const { operations } = useRedux("operations");
   const dispatch = useDispatch();
@@ -80,6 +82,7 @@ export const RecentOperations = ({
       title="Recent Operations: Live Network"
       titleLinkLabel="API"
       titleLink={`${horizonURL}/operations?order=desc&limit=20`}
+      noShadow={noShadow}
     >
       <Table
         id="last-10-operations"

--- a/frontend/src/components/RecentOperations/index.tsx
+++ b/frontend/src/components/RecentOperations/index.tsx
@@ -14,10 +14,8 @@ import { FetchLastOperationsActionResponse, Network } from "types";
 
 export const RecentOperations = ({
   network = Network.MAINNET,
-  noShadow = false,
 }: {
   network?: Network;
-  noShadow?: boolean;
 }) => {
   const { operations } = useRedux("operations");
   const dispatch = useDispatch();
@@ -82,7 +80,7 @@ export const RecentOperations = ({
       title="Recent Operations: Live Network"
       titleLinkLabel="API"
       titleLink={`${horizonURL}/operations?order=desc&limit=20`}
-      noShadow={noShadow}
+      noShadow={network === Network.MAINNET}
     >
       <Table
         id="last-10-operations"

--- a/frontend/src/components/TotalMonthlyOperations/index.tsx
+++ b/frontend/src/components/TotalMonthlyOperations/index.tsx
@@ -63,7 +63,7 @@ export const TotalMonthlyOperations = ({
             </div>
           </div>
 
-          <RecentOperations network={network} noShadow={true} />
+          <RecentOperations network={network} />
         </SectionCard>
       ) : (
         <RecentOperations network={network} />

--- a/frontend/src/components/TotalMonthlyOperations/index.tsx
+++ b/frontend/src/components/TotalMonthlyOperations/index.tsx
@@ -6,10 +6,6 @@ import { ActionStatus, Network } from "types";
 import { fetchLedgerOperations } from "ducks/ledgers";
 import { SectionCard } from "components/SectionCard";
 import { VerticalBarChart } from "components/charts/VerticalBarChart";
-import {
-  ledgerTransactionHistoryConfig,
-  networkConfig,
-} from "constants/settings";
 
 import "./styles.scss";
 import { RecentOperations } from "components/RecentOperations";
@@ -21,8 +17,6 @@ export const TotalMonthlyOperations = ({
 }) => {
   const { ledgers } = useRedux("ledgers");
   const dispatch = useDispatch();
-
-  const historyFilter = ledgerTransactionHistoryConfig["30D"];
 
   useEffect(() => {
     dispatch(fetchLedgerOperations());
@@ -46,30 +40,34 @@ export const TotalMonthlyOperations = ({
   }, [ledgers.ledgerOperations]);
 
   return (
-    <SectionCard
-      title="Total monthly operations"
-      titleLinkLabel="API"
-      titleLink={`/api/ledgers${historyFilter.endpointPrefix}${
-        networkConfig[Network.MAINNET].ledgerTransactionsHistorySuffix
-      }`}
-      isLoading={ledgers.status === ActionStatus.PENDING}
-      noData={!ledgers.ledgerOperations.length}
-    >
-      <div className="LedgerOperations__mainChart">
-        <div className="LedgerOperations__mainChart__container">
-          <VerticalBarChart
-            data={data.operations}
-            primaryValueName="Operations"
-            timeRange={VerticalBarChart.TimeRange.YEAR}
-            primaryValueTooltipDescription="ops"
-            primaryValueOnly
-            baseStartDate={data.fisrtDate}
-            maxLineOffset={550000000}
-          />
-        </div>
-      </div>
+    <>
+      {network === Network.MAINNET ? (
+        <SectionCard
+          title="Total monthly operations"
+          titleLinkLabel="API"
+          titleLink={`/api/ledgers/op_stats`}
+          isLoading={ledgers.status === ActionStatus.PENDING}
+          noData={!ledgers.ledgerOperations.length}
+        >
+          <div className="LedgerOperations__mainChart">
+            <div className="LedgerOperations__mainChart__container">
+              <VerticalBarChart
+                data={data.operations}
+                primaryValueName="Operations"
+                timeRange={VerticalBarChart.TimeRange.YEAR}
+                primaryValueTooltipDescription="ops"
+                primaryValueOnly
+                baseStartDate={data.fisrtDate}
+                maxLineOffset={550000000}
+              />
+            </div>
+          </div>
 
-      <RecentOperations network={network} />
-    </SectionCard>
+          <RecentOperations network={network} />
+        </SectionCard>
+      ) : (
+        <RecentOperations network={network} />
+      )}
+    </>
   );
 };

--- a/frontend/src/components/TotalMonthlyOperations/index.tsx
+++ b/frontend/src/components/TotalMonthlyOperations/index.tsx
@@ -63,7 +63,7 @@ export const TotalMonthlyOperations = ({
             </div>
           </div>
 
-          <RecentOperations network={network} />
+          <RecentOperations network={network} noShadow={true} />
         </SectionCard>
       ) : (
         <RecentOperations network={network} />


### PR DESCRIPTION
when verifying the v2 data I noticed one of the API links was to the wrong backend endpoint, so changed that here.

Also, the Total Monthly Operations chart (tracks sum of operations since 2015) we only have mainnet data for, so hiding that chart if we're on testnet