### PR TITLE
fix chart ui month off by 1, remove month redis refresh

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -12,8 +12,7 @@
     "clean": "rm -rf node_modules && rm -rf build",
     "test": "jest --forceExit",
     "build": "tsc --project .",
-    "redis:reset_day": "DEV=true ts-node ./src/redis/redisRefresh.ts day",
-    "redis:reset_month": "DEV=true ts-node ./src/redis/redisRefresh.ts month"
+    "redis:reset_day": "DEV=true ts-node ./src/redis/redisRefresh.ts day"
   },
   "dependencies": {
     "@google-cloud/bigquery": "^5.11.0",

--- a/backend/src/redis/redisRefresh.ts
+++ b/backend/src/redis/redisRefresh.ts
@@ -24,9 +24,8 @@ const MONTH = "month";
       REDIS_DEX_KEYS.DEX_TRADES_OVERALL,
       REDIS_DEX_KEYS.DEX_UNIQUE_ASSETS,
       REDIS_DEX_KEYS.DEX_ACTIVE_ACCOUNTS,
+      REDIS_LEDGER_KEYS.operation_stats,
     ];
-  } else if (process.argv[2] === MONTH) {
-    resetKeys = [REDIS_LEDGER_KEYS.operation_stats];
   }
 
   for (const k of resetKeys) {
@@ -42,7 +41,6 @@ const MONTH = "month";
     await getTradeData();
     await getUniqueAssetsData();
     await getActiveAccountsData();
-  } else if (process.argv[2] === MONTH) {
     await getOpStats();
   }
 

--- a/frontend/src/components/TotalMonthlyOperations/index.tsx
+++ b/frontend/src/components/TotalMonthlyOperations/index.tsx
@@ -29,7 +29,11 @@ export const TotalMonthlyOperations = ({
       const fisrtDate = new Date(reversedOperations[0].date);
 
       const operations = reversedOperations.map((operation) => ({
-        date: new Date(operation.date),
+        date: new Date(
+          parseInt(operation.date.split("-")[0]),
+          // monthIndex starts at 0
+          parseInt(operation.date.split("-")[1]) - 1,
+        ),
         primaryValue: operation.primaryValue,
       }));
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -233,7 +233,7 @@ export interface LedgerModuleItem {
 }
 
 export interface FetchLedgerOperationsResponse {
-  date: Date;
+  date: string;
   primaryValue: number;
 }
 


### PR DESCRIPTION
the total month ops chart UI was showing months off by 1 ([slack convo](https://stellarfoundation.slack.com/archives/C02U01CFSMS/p1663619275937869?thread_ts=1660157132.388869&cid=C02U01CFSMS))

also moving the cron job code for this data to update every day instead of every month. Originally I thought every month made sense since it's monthly data and to save BQ data costs. But looks like the cost is pretty negligible (600 mb, the other jobs are mostly > 1gb each), and it will be nice to see up to date data for this chart every day

