### PR TITLE
Update bq dataset

### DIFF
--- a/backend/src/bigQuery.ts
+++ b/backend/src/bigQuery.ts
@@ -16,7 +16,7 @@ if (process.env.DEV) {
 export const bqClient = new BigQuery(options);
 
 // TODO - drop the _2 when Hubble 2.0 is live
-const BQHistoryLedgersTable = "crypto-stellar.crypto_stellar_2.history_ledgers";
+const BQHistoryLedgersTable = "crypto-stellar.crypto_stellar.history_ledgers";
 
 export function getBqQueryByDate(date: string) {
   return `SELECT id FROM \`${BQHistoryLedgersTable}\` WHERE closed_at >= "${date}" ORDER BY sequence LIMIT 1;`;

--- a/backend/src/utils.ts
+++ b/backend/src/utils.ts
@@ -1,7 +1,7 @@
 import { bqClient } from "./bigQuery";
 import { getOrThrow, redisClient } from "./redis/redisSetup";
 
-export const bigQueryEndpointBase = "crypto-stellar.crypto_stellar_2";
+export const bigQueryEndpointBase = "crypto-stellar.crypto_stellar";
 
 export async function fetchBigQueryData(query: string) {
   try {


### PR DESCRIPTION
The dataset `crypto_stellar_2` is deprecated in favor of `crypto_stellar`. This updates the ledgers query and `bigQueryEndpointBase` to repoint to the final dataset.