### PR TITLE
fix big query table name

### DIFF
--- a/backend/src/bigQuery.ts
+++ b/backend/src/bigQuery.ts
@@ -15,8 +15,7 @@ if (process.env.DEV) {
 
 export const bqClient = new BigQuery(options);
 
-// TODO - drop the _2 when Hubble 2.0 is live
-const BQHistoryLedgersTable = "crypto-stellar.crypto_stellar_2.history_ledgers";
+const BQHistoryLedgersTable = "crypto-stellar.crypto_stellar.history_ledgers";
 
 export function getBqQueryByDate(date: string) {
   return `SELECT id FROM \`${BQHistoryLedgersTable}\` WHERE closed_at >= "${date}" ORDER BY sequence LIMIT 1;`;

--- a/backend/src/utils.ts
+++ b/backend/src/utils.ts
@@ -1,7 +1,7 @@
 import { bqClient } from "./bigQuery";
 import { getOrThrow, redisClient } from "./redis/redisSetup";
 
-export const bigQueryEndpointBase = "crypto-stellar.crypto_stellar_2";
+export const bigQueryEndpointBase = "crypto-stellar.crypto_stellar";
 
 export async function fetchBigQueryData(query: string) {
   try {


### PR DESCRIPTION
removes the _2 now that hubble 2.0 is live