### PR TITLE
test: Gateway API preview trigger (do not merge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,5 @@ before [ArgoCD](https://argo-prd-eks.stellar-ops.com/applications/stellar-dashbo
 deploys to production. If the job timed out, restart it to trigger the approval
 step again. Verify the deploy by checking ArgoCD shows **Synced/Healthy** and
 confirming changes on [dashboard.stellar.org](https://dashboard.stellar.org).
+
+<!-- gwapi preview trigger test -->


### PR DESCRIPTION
Throwaway PR to exercise the migrated PR-preview pipeline (stellar/pipelines#1088) end-to-end: verifies the Jenkins build applies `stellar-dashboard-06.yaml` and serves the preview via Gateway API HTTPRoute instead of nginx Ingress.

Will close once the preview HTTPRoute + 200 are verified. No product changes.