### PR TITLE
fix: raise /api/lumens rate limit to 1000/15min

### DIFF
--- a/backend/routes.ts
+++ b/backend/routes.ts
@@ -29,8 +29,20 @@ app.set("trust proxy", proxyAddr.compile(trustProxyCidrs));
 app.use(logger("combined"));
 
 // /api/lumens serves straight from the Redis cache, so it gets its own
-// higher limit and is excluded from the global and general limiters.
+// higher limit and is excluded from the global and general limiters. The
+// exemption only covers requests the GET route actually serves (Express
+// routing is case-insensitive, tolerates trailing slashes, and answers HEAD
+// through GET handlers) — anything else stays fully rate limited.
 const LUMENS_V1_PATH = "/api/lumens";
+const isLumensV1Request = (req: express.Request): boolean => {
+  const normalizedPath = (req.baseUrl + req.path)
+    .toLowerCase()
+    .replace(/\/+$/, "");
+  return (
+    (req.method === "GET" || req.method === "HEAD") &&
+    normalizedPath === LUMENS_V1_PATH
+  );
+};
 
 // Global rate limiting for all requests (including static files)
 const globalLimiter = rateLimit({
@@ -43,8 +55,7 @@ const globalLimiter = rateLimit({
   },
   standardHeaders: true,
   legacyHeaders: false,
-  skip: (req) =>
-    process.env.DEV === "true" || req.baseUrl + req.path === LUMENS_V1_PATH,
+  skip: (req) => process.env.DEV === "true" || isLumensV1Request(req),
 });
 
 // Apply global rate limiting to all requests
@@ -55,7 +66,7 @@ const createRateLimit = (
   windowMs: number,
   max: number,
   message: string,
-  skipPath?: string,
+  skipRequest?: (req: express.Request) => boolean,
 ) => {
   return rateLimit({
     windowMs,
@@ -70,7 +81,7 @@ const createRateLimit = (
     // Skip rate limiting in development
     skip: (req) =>
       process.env.DEV === "true" ||
-      (skipPath !== undefined && req.baseUrl + req.path === skipPath),
+      (skipRequest !== undefined && skipRequest(req)),
   });
 };
 
@@ -79,7 +90,7 @@ const generalApiLimiter = createRateLimit(
   15 * 60 * 1000, // 15 minutes
   100,
   "Too many API requests from this IP, please try again later.",
-  LUMENS_V1_PATH, // /api/lumens has its own, higher limit
+  isLumensV1Request, // /api/lumens has its own, higher limit
 );
 // /api/lumens is served from the Redis cache, so it can take a much higher
 // rate than the general API limit.

--- a/backend/routes.ts
+++ b/backend/routes.ts
@@ -28,6 +28,10 @@ app.set("trust proxy", proxyAddr.compile(trustProxyCidrs));
 
 app.use(logger("combined"));
 
+// /api/lumens serves straight from the Redis cache, so it gets its own
+// higher limit and is excluded from the global and general limiters.
+const LUMENS_V1_PATH = "/api/lumens";
+
 // Global rate limiting for all requests (including static files)
 const globalLimiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
@@ -39,14 +43,20 @@ const globalLimiter = rateLimit({
   },
   standardHeaders: true,
   legacyHeaders: false,
-  skip: () => process.env.DEV === "true",
+  skip: (req) =>
+    process.env.DEV === "true" || req.baseUrl + req.path === LUMENS_V1_PATH,
 });
 
 // Apply global rate limiting to all requests
 app.use(globalLimiter);
 
 // Rate limiting configuration
-const createRateLimit = (windowMs: number, max: number, message: string) => {
+const createRateLimit = (
+  windowMs: number,
+  max: number,
+  message: string,
+  skipPath?: string,
+) => {
   return rateLimit({
     windowMs,
     max,
@@ -58,7 +68,9 @@ const createRateLimit = (windowMs: number, max: number, message: string) => {
     standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
     legacyHeaders: false, // Disable the `X-RateLimit-*` headers
     // Skip rate limiting in development
-    skip: () => process.env.DEV === "true",
+    skip: (req) =>
+      process.env.DEV === "true" ||
+      (skipPath !== undefined && req.baseUrl + req.path === skipPath),
   });
 };
 
@@ -66,6 +78,14 @@ const createRateLimit = (windowMs: number, max: number, message: string) => {
 const generalApiLimiter = createRateLimit(
   15 * 60 * 1000, // 15 minutes
   100,
+  "Too many API requests from this IP, please try again later.",
+  LUMENS_V1_PATH, // /api/lumens has its own, higher limit
+);
+// /api/lumens is served from the Redis cache, so it can take a much higher
+// rate than the general API limit.
+const lumensLimiter = createRateLimit(
+  15 * 60 * 1000, // 15 minutes
+  1000,
   "Too many API requests from this IP, please try again later.",
 );
 
@@ -200,7 +220,7 @@ if (process.env.DEV === "true") {
 
 // API Routes with appropriate rate limiting
 app.get("/api/ledgers/public", strictApiLimiter, ledgers.handler);
-app.get("/api/lumens", lumens.v1Handler);
+app.get("/api/lumens", lumensLimiter, lumens.v1Handler);
 
 app.get("/api/v2/lumens", lumensV2V3.v2Handler);
 /* For CoinMarketCap - heavily rate limited */

--- a/test/tests/integration/backend.ts
+++ b/test/tests/integration/backend.ts
@@ -51,10 +51,10 @@ describe("integration", function () {
       chai
         .expect(body.programs.productAndInnovation)
         .to.match(DECIMAL_NUMBER_REGEX);
+      chai.expect(body.programs.growth).to.match(DECIMAL_NUMBER_REGEX);
       chai
-        .expect(body.programs.growth)
+        .expect(body.programs.assetsAndLiquidity)
         .to.match(DECIMAL_NUMBER_REGEX);
-      chai.expect(body.programs.assetsAndLiquidity).to.match(DECIMAL_NUMBER_REGEX);
     });
 
     it("/api/v2/lumens should return successfuly with data", async function () {
@@ -192,6 +192,35 @@ describe("integration", function () {
       chai.expect(body).to.be.a("string");
       chai.expect(body).to.not.equal("");
       chai.expect(body).to.match(DECIMAL_NUMBER_REGEX);
+    });
+
+    describe("rate limiting", function () {
+      // Rate limiters are skipped when DEV=true (how tests run), so toggle
+      // it off to exercise them.
+      let originalDev: string | undefined;
+
+      before(function () {
+        originalDev = process.env.DEV;
+        process.env.DEV = "false";
+      });
+
+      after(function () {
+        process.env.DEV = originalDev;
+      });
+
+      it("/api/lumens should have its own higher rate limit", async function () {
+        const { headers } = await request(app).get("/api/lumens").expect(200);
+
+        chai.expect(headers["ratelimit-limit"]).to.equal("1000");
+      });
+
+      it("other api endpoints should keep the general rate limit", async function () {
+        const { headers } = await request(app)
+          .get("/api/v2/lumens")
+          .expect(200);
+
+        chai.expect(headers["ratelimit-limit"]).to.equal("100");
+      });
     });
 
     it("/api/ledgers/public should return successfully with data", async function () {

--- a/test/tests/integration/backend.ts
+++ b/test/tests/integration/backend.ts
@@ -223,9 +223,7 @@ describe("integration", function () {
       });
 
       it("path variants of GET /api/lumens should keep the higher limit", async function () {
-        const { headers } = await request(app)
-          .get("/api/lumens/")
-          .expect(200);
+        const { headers } = await request(app).get("/api/lumens/").expect(200);
 
         chai.expect(headers["ratelimit-limit"]).to.equal("1000");
       });
@@ -234,6 +232,51 @@ describe("integration", function () {
         const { headers } = await request(app).post("/api/lumens").expect(404);
 
         chai.expect(headers["ratelimit-limit"]).to.equal("100");
+      });
+
+      // The limiters key on client IP, so spoofing X-Forwarded-For (trusted
+      // from loopback) gives each test a fresh, isolated budget.
+      it("general api traffic should not consume the /api/lumens budget", async function () {
+        const ip = "203.0.113.10";
+
+        // Exhaust the general API budget for this IP...
+        for (let i = 0; i < 100; i++) {
+          await request(app)
+            .get("/api/v2/lumens")
+            .set("X-Forwarded-For", ip)
+            .expect(200);
+        }
+        await request(app)
+          .get("/api/v2/lumens")
+          .set("X-Forwarded-For", ip)
+          .expect(429);
+
+        // ...and /api/lumens is still available, having only counted its own
+        // requests.
+        const { headers } = await request(app)
+          .get("/api/lumens")
+          .set("X-Forwarded-For", ip)
+          .expect(200);
+
+        chai.expect(headers["ratelimit-remaining"]).to.equal("999");
+      });
+
+      it("/api/lumens traffic should not consume the general api budget", async function () {
+        const ip = "203.0.113.20";
+
+        for (let i = 0; i < 5; i++) {
+          await request(app)
+            .get("/api/lumens")
+            .set("X-Forwarded-For", ip)
+            .expect(200);
+        }
+
+        const { headers } = await request(app)
+          .get("/api/v2/lumens")
+          .set("X-Forwarded-For", ip)
+          .expect(200);
+
+        chai.expect(headers["ratelimit-remaining"]).to.equal("99");
       });
     });
 

--- a/test/tests/integration/backend.ts
+++ b/test/tests/integration/backend.ts
@@ -221,6 +221,20 @@ describe("integration", function () {
 
         chai.expect(headers["ratelimit-limit"]).to.equal("100");
       });
+
+      it("path variants of GET /api/lumens should keep the higher limit", async function () {
+        const { headers } = await request(app)
+          .get("/api/lumens/")
+          .expect(200);
+
+        chai.expect(headers["ratelimit-limit"]).to.equal("1000");
+      });
+
+      it("non-GET requests to /api/lumens should stay rate limited", async function () {
+        const { headers } = await request(app).post("/api/lumens").expect(404);
+
+        chai.expect(headers["ratelimit-limit"]).to.equal("100");
+      });
     });
 
     it("/api/ledgers/public should return successfully with data", async function () {


### PR DESCRIPTION
### What

- Give `GET /api/lumens` its own rate limit of 1000 requests / 15 minutes per IP (was 100 via the general API limiter)
- Exclude `/api/lumens` from the global and general limiters so other traffic from the same IP doesn't eat into its budget; all other endpoints keep their existing limits
- Add integration tests asserting the `RateLimit-Limit` header is `1000` on `/api/lumens` and still `100` on other API routes

### Why

- Consumers of `/api/lumens` are hitting the 100 req / 15 min general API limit
- The endpoint serves straight from the Redis cache, so a 10x higher limit adds no meaningful load